### PR TITLE
Version 0.3.0: Multiplication

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.2.0
+module_version: 0.3.0
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -328,6 +328,22 @@ extension Dice {
     public static func - (lhs: Dice, rhs: Int) -> Dice {
         return lhs + (-rhs)
     }
+    public static func * (lhs: Dice, rhs: Int) -> Dice {
+        var dice = lhs.copy()
+        for (die, _) in lhs.dice {
+            dice += die * (rhs - 1)
+        }
+        dice += lhs.modifier * (rhs - 1)
+        return dice
+    }
+    public static func * (lhs: Int, rhs: Dice) -> Dice {
+        var dice = rhs.copy()
+        for (die, _) in rhs.dice {
+            dice += die * (lhs - 1)
+        }
+        dice += rhs.modifier * (lhs - 1)
+        return dice
+    }
 }
 extension Dice {
     public static func += (lhs: inout Dice, rhs: Dice) {
@@ -341,5 +357,8 @@ extension Dice {
     }
     public static func -= (lhs: inout Dice, rhs: Int) {
         lhs = lhs - rhs
+    }
+    public static func *= (lhs: inout Dice, rhs: Int) {
+        lhs = lhs * rhs
     }
 }

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -53,6 +53,8 @@ public class Dice {
     ///     // diceArray is [d6, d6, d4]
     public let dice: [Die: Int]
     /// The number of dice in this `Dice` instance.
+    ///
+    /// - Since: 0.2.0
     public var numberOfDice: Int {
         var c = 0
         for (_, count) in dice {
@@ -145,6 +147,8 @@ extension Dice: Rollable {
     /// The minimum possible result from using the `roll()` method.
     ///
     /// This method simulates rolling a `1` on *every* die in this `Dice` object. It also includes the modifier, if applicable.
+    ///
+    /// - Since: 0.2.0
     public var minimumResult: Roll {
         return Roll(value: numberOfDice + modifier)
     }
@@ -152,6 +156,8 @@ extension Dice: Rollable {
     /// The maximum possible result from using the `roll()` method.
     ///
     /// This method simulates rolling the maximum on every die in this `Dice` object. It also includes the modifier, if applicable.
+    ///
+    /// - Since: 0.2.0
     public var maximumResult: Roll {
         var total = modifier
         for (die, count) in dice {

--- a/Sources/DiceKit/DiceKit.swift
+++ b/Sources/DiceKit/DiceKit.swift
@@ -24,8 +24,12 @@ public protocol Rollable {
     func roll() -> Roll
     
     /// The minimum possible result from using the `roll()` method.
+    ///
+    /// - Since: 0.2.0
     var minimumResult: Roll { get }
     
     /// The maximum possible result from using the `roll()` method.
+    ///
+    /// - Since: 0.2.0
     var maximumResult: Roll { get }
 }

--- a/Sources/DiceKit/Die.swift
+++ b/Sources/DiceKit/Die.swift
@@ -139,4 +139,12 @@ extension Die {
     public static func + (lhs: Int, rhs: Die) -> Dice {
         return Dice(rhs, withModifier: lhs)
     }
+    public static func * (lhs: Die, rhs: Int) -> Dice {
+        let dice = [Die].init(repeating: lhs, count: rhs)
+        return Dice(dice: dice)
+    }
+    public static func * (lhs: Int, rhs: Die) -> Dice {
+        let dice = [Die].init(repeating: rhs, count: lhs)
+        return Dice(dice: dice)
+    }
 }

--- a/Sources/DiceKit/Die.swift
+++ b/Sources/DiceKit/Die.swift
@@ -45,6 +45,8 @@ extension Die: Rollable {
     /// The minimum possible result from using the `roll()` method.
     ///
     /// This method simulates rolling a `1` on this die.
+    ///
+    /// - Since: 0.2.0
     public var minimumResult: Roll {
         return Roll(value: 1)
     }
@@ -52,6 +54,8 @@ extension Die: Rollable {
     /// The maximum possible result from using the `roll()` method.
     ///
     /// This method simulates rolling the maximum on this die.
+    ///
+    /// - Since: 0.2.0
     public var maximumResult: Roll {
         return Roll(value: sides)
     }


### PR DESCRIPTION
Both `Die` and `Dice` can now be multiplied with `Int`. Examples:
```swift
let d6 = Die.d6
let threeD6 = d6 * 3
threeD6.debugDescription // 3d6

let dFourPlusFour = Die.d4 + 4
let threeTimesIt = dFourPlusFour * 3
threeTimesIt.debugDescription // 3d4 + 12
```

Version 0.2.0 additions also now have documentation (d70a925). These additions don't because they aren't documented at all.

Closes #10 and closes #11