### PR TITLE
Version 0.7.0: Swift 4.2/Xcode 10 and LICENSE

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.6.0
+module_version: 0.7.0
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 - SWIFT_VERSION=4.1.1
 - SWIFT_VERSION=4.1.2
 - SWIFT_VERSION=4.1.3
+- SWIFT_VERSION=4.2
 install:
 - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ os: osx
 language: generic
 sudo: false
 dist: trusty
-osx_image: xcode9
+osx_image: xcode10
 env:
 - SWIFT_VERSION=4.0
 - SWIFT_VERSION=4.0.2

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Samasaur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Version 0.7.0 tests on Swift 4.2/Xcode 10 and adds a LICENSE file.

This starts implementing #14

Next steps:

1. Bump version
1. Wait for CI
2. Merge
3. `git tag -s v0.7.0 -m "Version 0.7.0: Swift 4.2/Xcode 10 and LICENSE"`
4. `git push --tags`
5. `git checkout development` and `git rebase master`
6. `git push`