### PR TITLE
Add string parsing

### DIFF
--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -228,8 +228,10 @@ public class Dice {
         
         var tempDice: [Die: Int] = [:]
         for (d, c) in dice {
-            if c <= 0 {
+            if c < 0 {
                 return nil
+            } else if c == 0 {
+                continue
             }
             tempDice[Die(sides: d)!] = c
         }

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -164,6 +164,55 @@ public class Dice {
         self.dice = newDice
         self.modifier = modifier
     }
+    public init?(_ str: String) {
+        var dice: [Int: Int] = [:]
+        var mods: [Int] = []
+        
+        guard Set(str).isSubset(of: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "+", "-", "D", "d"]) else {
+            return nil
+        }
+        
+        let plusSplit = str.split(whereSeparator: { $0 == "+" })
+        for positiveExp in plusSplit {
+            let exp = positiveExp.split(whereSeparator: { $0 == "-" })
+            let ex = String(exp.first!)//positive
+            if ex.isNumeric {
+                mods.append(Int(ex)!)
+            } else if ex.contains("D") || ex.contains("d") {
+                let d = ex.split(whereSeparator: { $0 == "d" || $0 == "D" })
+                if d.count == 1 {
+                    let sides = Int(String(d.first!))!
+                    dice[sides] = (dice[sides] ?? 0) + 1
+                } else if d.count == 2 {
+                    let m = Int(String(d.first!))!
+                    let s = Int(String(d.last!))!
+                    dice[s] = (dice[s] ?? 0) + m
+                } else { return nil }
+            } else { return nil }
+            for ex in exp.dropFirst() {//negative
+                if String(ex).isNumeric {
+                    mods.append(-Int(String(ex))!)
+                } else if ex.contains("D") || ex.contains("d") {
+                    let d = ex.split(whereSeparator: { $0 == "d" || $0 == "D" })
+                    if d.count == 1 {
+                        let sides = Int(String(d.first!))!
+                        dice[sides] = (dice[sides] ?? 0) - 1
+                    } else if d.count == 2 {
+                        let m = Int(String(d.first!))!
+                        let s = Int(String(d.last!))!
+                        dice[s] = (dice[s] ?? 0) - m
+                    } else { return nil }
+                } else { return nil }
+            }
+        }
+        
+        var tempDice: [Die: Int] = [:]
+        for (d, c) in dice {
+            tempDice[Die(sides: d)!] = c
+        }
+        self.dice = tempDice
+        self.modifier = mods.sum
+    }
     /// Creates a new `Dice` object that is a copy of the given `Dice` object.
     ///
     /// - Parameter other: The other `Dice` object to copy.
@@ -174,6 +223,14 @@ public class Dice {
         }
         self.dice = newDice
         modifier = other.modifier
+    }
+}
+
+extension String {
+    var isNumeric: Bool {
+        guard !self.isEmpty else { return false }
+        let nums: Set<Character> = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        return Set(self).isSubset(of: nums)
     }
 }
 

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -175,39 +175,60 @@ public class Dice {
         let plusSplit = str.split(whereSeparator: { $0 == "+" })
         for positiveExp in plusSplit {
             let exp = positiveExp.split(whereSeparator: { $0 == "-" })
-            let ex = String(exp.first!)//positive
-            if ex.isNumeric {
-                mods.append(Int(ex)!)
-            } else if ex.contains("D") || ex.contains("d") {
-                let d = ex.split(whereSeparator: { $0 == "d" || $0 == "D" })
-                if d.count == 1 {
-                    let sides = Int(String(d.first!))!
-                    dice[sides] = (dice[sides] ?? 0) + 1
-                } else if d.count == 2 {
-                    let m = Int(String(d.first!))!
-                    let s = Int(String(d.last!))!
-                    dice[s] = (dice[s] ?? 0) + m
-                } else { return nil }
-            } else { return nil }
-            for ex in exp.dropFirst() {//negative
-                if String(ex).isNumeric {
-                    mods.append(-Int(String(ex))!)
+            if positiveExp.starts(with: "-") {
+                for ex in exp {//negative
+                    if String(ex).isNumeric {
+                        mods.append(-Int(String(ex))!)
+                    } else if ex.contains("D") || ex.contains("d") {
+                        let d = ex.split(whereSeparator: { $0 == "d" || $0 == "D" })
+                        if d.count == 1 {
+                            let sides = Int(String(d.first!))!
+                            dice[sides] = (dice[sides] ?? 0) - 1
+                        } else if d.count == 2 {
+                            let m = Int(String(d.first!))!
+                            let s = Int(String(d.last!))!
+                            dice[s] = (dice[s] ?? 0) - m
+                        } else { return nil }
+                    } else { return nil }
+                }
+            } else {
+                let ex = String(exp.first!)//positive
+                if ex.isNumeric {
+                    mods.append(Int(ex)!)
                 } else if ex.contains("D") || ex.contains("d") {
                     let d = ex.split(whereSeparator: { $0 == "d" || $0 == "D" })
                     if d.count == 1 {
                         let sides = Int(String(d.first!))!
-                        dice[sides] = (dice[sides] ?? 0) - 1
+                        dice[sides] = (dice[sides] ?? 0) + 1
                     } else if d.count == 2 {
                         let m = Int(String(d.first!))!
                         let s = Int(String(d.last!))!
-                        dice[s] = (dice[s] ?? 0) - m
+                        dice[s] = (dice[s] ?? 0) + m
                     } else { return nil }
                 } else { return nil }
+                for ex in exp.dropFirst() {//negative
+                    if String(ex).isNumeric {
+                        mods.append(-Int(String(ex))!)
+                    } else if ex.contains("D") || ex.contains("d") {
+                        let d = ex.split(whereSeparator: { $0 == "d" || $0 == "D" })
+                        if d.count == 1 {
+                            let sides = Int(String(d.first!))!
+                            dice[sides] = (dice[sides] ?? 0) - 1
+                        } else if d.count == 2 {
+                            let m = Int(String(d.first!))!
+                            let s = Int(String(d.last!))!
+                            dice[s] = (dice[s] ?? 0) - m
+                        } else { return nil }
+                    } else { return nil }
+                }
             }
         }
         
         var tempDice: [Die: Int] = [:]
         for (d, c) in dice {
+            if c <= 0 {
+                return nil
+            }
             tempDice[Die(sides: d)!] = c
         }
         self.dice = tempDice

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -164,6 +164,13 @@ public class Dice {
         self.dice = newDice
         self.modifier = modifier
     }
+    /// Creates a new `Dice` object from the specified string in dice notation.
+    ///
+    /// You cannot have a negative die **AS A RESULT** (`-d6`), a die with negative sides (`d-6`), or a die with 0 sides (`d0`). You cannot have an unreal modifier or use any operator except for addition and subtraction.
+    ///
+    /// You can have `-d6`s in your string, so long as they cancel each other out so that the final result is at least `0d6`.
+    ///
+    /// - Parameter str: The string to convert.
     public init?(_ str: String) {
         var dice: [Int: Int] = [:]
         var mods: [Int] = []

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -226,14 +226,6 @@ public class Dice {
     }
 }
 
-extension String {
-    var isNumeric: Bool {
-        guard !self.isEmpty else { return false }
-        let nums: Set<Character> = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
-        return Set(self).isSubset(of: nums)
-    }
-}
-
 extension Dice: Rollable {
     /// Rolls this `Dice` object.
     ///

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -168,6 +168,8 @@ public class Dice {
         var dice: [Int: Int] = [:]
         var mods: [Int] = []
         
+        let str = str.filter({ $0 != " " })
+        
         guard Set(str).isSubset(of: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "+", "-", "D", "d"]) else {
             return nil
         }

--- a/Sources/DiceKit/DiceKit.swift
+++ b/Sources/DiceKit/DiceKit.swift
@@ -84,6 +84,14 @@ internal extension Array where Element == Roll {
     }
 }
 
+internal extension String {
+    internal var isNumeric: Bool {
+        guard !self.isEmpty else { return false }
+        let nums: Set<Character> = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        return Set(self).isSubset(of: nums)
+    }
+}
+
 public typealias DKDie = Die
 public typealias DKDice = Dice
 public typealias DKRoll = Roll

--- a/Sources/DiceKit/Die.swift
+++ b/Sources/DiceKit/Die.swift
@@ -27,6 +27,11 @@ public class Die {
         }
         self.sides = sides
     }
+    /// Creates a new `Die` from the given string in dice notation.
+    ///
+    /// You cannot have a negative die (`-d6`), a die with negative sides (`d-6`), or a die with 0 sides (`d0`). Because this is a `Die` initializer, you can only have one die (no `2d6`).
+    ///
+    /// - Parameter str: The string to convert from.
     public init?(_ str: String) {
         if str.isEmpty {
             return nil

--- a/Sources/DiceKit/Die.swift
+++ b/Sources/DiceKit/Die.swift
@@ -27,6 +27,28 @@ public class Die {
         }
         self.sides = sides
     }
+    public init?(_ str: String) {
+        if str.isEmpty {
+            return nil
+        }
+        if let _ = Int(str.prefix(1)) {
+            //number
+            guard let num = Int(str) else { return nil }
+            guard num > 0 else { return nil }
+            self.sides = num
+        } else if str.prefix(1).caseInsensitiveCompare("D") == .orderedSame {
+            str.dropFirst()
+            if let _ = Int(str.prefix(1)) {
+                guard let num = Int(str) else { return nil }
+                guard num > 0 else { return nil }
+                self.sides = num
+            } else {
+                return nil
+            }
+        } else {
+            return nil
+        }
+    }
     /// Creates a new `Die` that is a copy of the given `Die`.
     ///
     /// - Parameter other: The other `Die` to copy.

--- a/Sources/DiceKit/Die.swift
+++ b/Sources/DiceKit/Die.swift
@@ -31,15 +31,14 @@ public class Die {
         if str.isEmpty {
             return nil
         }
-        if let _ = Int(str.prefix(1)) {
-            //number
+        if str.isNumeric {
             guard let num = Int(str) else { return nil }
             guard num > 0 else { return nil }
             self.sides = num
         } else if String(str.prefix(1)).caseInsensitiveCompare("D") == .orderedSame {
-            let s = str.dropFirst()
-            if let _ = Int(s.prefix(1)) {
-                guard let num = Int(s) else { return nil }
+            let remaining = String(str.dropFirst())
+            if remaining.isNumeric {
+                guard let num = Int(remaining) else { return nil }
                 guard num > 0 else { return nil }
                 self.sides = num
             } else {

--- a/Sources/DiceKit/Die.swift
+++ b/Sources/DiceKit/Die.swift
@@ -36,10 +36,10 @@ public class Die {
             guard let num = Int(str) else { return nil }
             guard num > 0 else { return nil }
             self.sides = num
-        } else if str.prefix(1).caseInsensitiveCompare("D") == .orderedSame {
-            str.dropFirst()
-            if let _ = Int(str.prefix(1)) {
-                guard let num = Int(str) else { return nil }
+        } else if String(str.prefix(1)).caseInsensitiveCompare("D") == .orderedSame {
+            let s = str.dropFirst()
+            if let _ = Int(s.prefix(1)) {
+                guard let num = Int(s) else { return nil }
                 guard num > 0 else { return nil }
                 self.sides = num
             } else {

--- a/Tests/DiceKitTests/DiceTests.swift
+++ b/Tests/DiceKitTests/DiceTests.swift
@@ -41,8 +41,28 @@ final class DiceTests: XCTestCase {
         XCTAssertEqual(negative5_2, Dice(dice: [], withModifier: -5))
     }
     
-    func testMultipleDieStringParsing() {
+    func testMultipleRepeatedDieStringParsing() {
+        let dice2d6 = Dice("2d6")
+        let dice3d4 = Dice("3D4")
+        let dice12d12 = Dice("12d12")
+        let dice1d100 = Dice("1d100")
+        let dice1000d1 = Dice("1000d1")
         
+        XCTAssertNotNil(dice2d6)
+        XCTAssertNotNil(dice3d4)
+        XCTAssertNotNil(dice12d12)
+        XCTAssertNotNil(dice1d100)
+        XCTAssertNotNil(dice1000d1)
+        
+        XCTAssertEqual(dice2d6, Dice(Die.d6, Die.d6))
+        XCTAssertEqual(dice3d4, Dice(Die.d4, Die.d4, Die.d4))
+        XCTAssertEqual(dice12d12, Dice((Die.d12, 12)))
+        XCTAssertEqual(dice1d100, Dice(Die.d100))
+        XCTAssertEqual(dice1000d1, Dice((Die(sides: 1)!, 1000)))
+    }
+    
+    func testMultipleSeparateDieStringParsing() {
+        let dice2d6 = Dice("2d6")
     }
     
     func testMultipleModifierStringParsing() {

--- a/Tests/DiceKitTests/DiceTests.swift
+++ b/Tests/DiceKitTests/DiceTests.swift
@@ -90,7 +90,23 @@ final class DiceTests: XCTestCase {
     }
     
     func testMultipleModifierStringParsing() {
+        let _2plus3 = Dice("2+3")
+        let _7minus2 = Dice("7-2")
+        let negative2plus7 = Dice("-2+7")
+        let negative2minus3 = Dice("-2-3")
+        let _2minus7 = Dice("+2-7")
         
+        XCTAssertNotNil(_2plus3)
+        XCTAssertNotNil(_7minus2)
+        XCTAssertNotNil(negative2plus7)
+        XCTAssertNotNil(negative2minus3)
+        XCTAssertNotNil(_2minus7)
+        
+        XCTAssertEqual(_2plus3, Dice(dice: [], withModifier: 5))
+        XCTAssertEqual(_7minus2, Dice(dice: [], withModifier: 5))
+        XCTAssertEqual(negative2plus7, Dice(dice: [], withModifier: 5))
+        XCTAssertEqual(negative2minus3, Dice(dice: [], withModifier: -5))
+        XCTAssertEqual(_2minus7, Dice(dice: [], withModifier: -5))
     }
     
     func testSingleDieAndSingleModifierStringParsing() {

--- a/Tests/DiceKitTests/DiceTests.swift
+++ b/Tests/DiceKitTests/DiceTests.swift
@@ -2,6 +2,14 @@ import XCTest
 @testable import DiceKit
 
 final class DiceTests: XCTestCase {
+    func testEmptyStringParsing() {
+        let empty = Dice("")
+        
+        XCTAssertNotNil(empty)
+        
+        XCTAssertEqual(empty, Dice(dice: [], withModifier: 0))
+    }
+    
     func testSingleDieStringParsing() {
         let dice6_1 = Dice("d6")
         let dice6_2 = Dice("D6")
@@ -143,6 +151,18 @@ final class DiceTests: XCTestCase {
     }
     
     func testInvalidStringParsing() {
+        // Assorted
+        XCTAssertNil(Dice("d")) // d without value
+        XCTAssertNil(Dice("q1")) // other that d in front
+        XCTAssertNil(Dice("d1b")) // binary (other form with d)
+        XCTAssertNil(Dice("1o")) // octal (other forw without d)
+        XCTAssertNil(Dice("one")) // spelled out
+        XCTAssertNil(Dice("A")) // hexadecimal
+        XCTAssertNil(Dice("DiceKit")) // string
+        XCTAssertNil(Dice("d+6")) // split
         
+        //Negative
+        XCTAssertNil(Dice("-d6"))
+        XCTAssertNil(Dice("d-6"))
     }
 }

--- a/Tests/DiceKitTests/DiceTests.swift
+++ b/Tests/DiceKitTests/DiceTests.swift
@@ -2,7 +2,58 @@ import XCTest
 @testable import DiceKit
 
 final class DiceTests: XCTestCase {
-    func testExample() {
+    func testSingleDieStringParsing() {
+        let dice6_1 = Dice("d6")
+        let dice6_2 = Dice("D6")
+        let dice12 = Dice("d12")
+        let dice100 = Dice("d100")
+        let dice726 = Dice("d726")
+        
+        XCTAssertNotNil(dice6_1)
+        XCTAssertNotNil(dice6_2)
+        XCTAssertNotNil(dice12)
+        XCTAssertNotNil(dice100)
+        XCTAssertNotNil(dice726)
+        
+        XCTAssertEqual(dice6_1, Dice(Die.d6))
+        XCTAssertEqual(dice6_2, Dice(Die.d6))
+        XCTAssertEqual(dice12, Dice(Die.d12))
+        XCTAssertEqual(dice100, Dice(Die.d100))
+        XCTAssertEqual(dice726, Dice(Die(sides: 726)!))
+        
+        XCTAssertNil(Dice("-d6"))
+    }
+    
+    func testSingleModifierStringParsing() {
+        let positive5_1 = Dice("5")
+        let positive5_2 = Dice("+5")
+        let negative5_1 = Dice("-5")
+        let negative5_2 = Dice("+-5")
+        
+        XCTAssertNotNil(positive5_1)
+        XCTAssertNotNil(positive5_2)
+        XCTAssertNotNil(negative5_1)
+        XCTAssertNotNil(negative5_2)
+        
+        XCTAssertEqual(positive5_1, Dice(dice: [], withModifier: 5))
+        XCTAssertEqual(positive5_2, Dice(dice: [], withModifier: 5))
+        XCTAssertEqual(negative5_1, Dice(dice: [], withModifier: -5))
+        XCTAssertEqual(negative5_2, Dice(dice: [], withModifier: -5))
+    }
+    
+    func testMultipleDieStringParsing() {
+        
+    }
+    
+    func testMultipleModifierStringParsing() {
+        
+    }
+    
+    func testSingleDieAndSingleModifierStringParsing() {
+        
+    }
+    
+    func testMultipleDieAndMultipleModifierStringParsing() {
         
     }
 }

--- a/Tests/DiceKitTests/DiceTests.swift
+++ b/Tests/DiceKitTests/DiceTests.swift
@@ -58,11 +58,35 @@ final class DiceTests: XCTestCase {
         XCTAssertEqual(dice3d4, Dice(Die.d4, Die.d4, Die.d4))
         XCTAssertEqual(dice12d12, Dice((Die.d12, 12)))
         XCTAssertEqual(dice1d100, Dice(Die.d100))
-        XCTAssertEqual(dice1000d1, Dice((Die(sides: 1)!, 1000)))
+        XCTAssertEqual(dice1000d1, Dice(Die(sides: 1)!, count: 1000))
     }
     
     func testMultipleSeparateDieStringParsing() {
-        let dice2d6 = Dice("2d6")
+        let dice2d6withSpaces = Dice("d6 + 1d6")
+        let dice2d6withoutSpaces = Dice("d6+1d6")
+        let dice1d4plus1d6withSpaces = Dice("d4 + 1d6")
+        let dice1d4plus1d6withoutSpaces = Dice("1d4+d6")
+        
+        XCTAssertNotNil(dice2d6withSpaces)
+        XCTAssertNotNil(dice2d6withoutSpaces)
+        XCTAssertNotNil(dice1d4plus1d6withSpaces)
+        XCTAssertNotNil(dice1d4plus1d6withoutSpaces)
+        
+        XCTAssertEqual(dice2d6withSpaces, Dice(Die.d6, Die.d6))
+        XCTAssertEqual(dice2d6withoutSpaces, Dice(Die.d6, Die.d6))
+        XCTAssertEqual(dice1d4plus1d6withSpaces, Dice(Die.d4, Die.d6))
+        XCTAssertEqual(dice1d4plus1d6withoutSpaces, Dice(Die.d4, Die.d6))
+        
+        
+        
+        let dice6d6withSpaces = Dice("d6 + 2d6 + 3d6")
+        let dice6d6withoutSpaces = Dice("d6+2d6+3d6")
+        
+        XCTAssertNotNil(dice6d6withSpaces)
+        XCTAssertNotNil(dice6d6withoutSpaces)
+        
+        XCTAssertEqual(dice6d6withSpaces, Dice(Die.d6, count: 6))
+        XCTAssertEqual(dice6d6withoutSpaces, Dice(Die.d6, count: 6))
     }
     
     func testMultipleModifierStringParsing() {

--- a/Tests/DiceKitTests/DiceTests.swift
+++ b/Tests/DiceKitTests/DiceTests.swift
@@ -100,4 +100,8 @@ final class DiceTests: XCTestCase {
     func testMultipleDieAndMultipleModifierStringParsing() {
         
     }
+    
+    func testInvalidStringParsing() {
+        
+    }
 }

--- a/Tests/DiceKitTests/DiceTests.swift
+++ b/Tests/DiceKitTests/DiceTests.swift
@@ -147,7 +147,68 @@ final class DiceTests: XCTestCase {
     }
     
     func testMultipleDieAndMultipleModifierStringParsing() {
+        //2d6+12
+        let D6plus6plus6plusD6 = Dice("d6+6+6+d6")
+        let _6plusD6plusD6plus6 = Dice("6+d6+d6+6")
+        let D6plus6plusD6plus6 = Dice("d6+6+d6+6")
+        let _6plusD6plus6plusD6 = Dice("6+d6+6+d6")
         
+        //2d4-8
+        let D4minus4minus4plusD4 = Dice("d4-4-4+d4")
+        let negative4plusD4plusD4minus4 = Dice("-4+d4+d4-4")
+        let D4minus4plusD4minus4 = Dice("d4-4+d4-4")
+        let negative4plusD4minus4plusD4 = Dice("-4+d4-4+d4")
+        
+        //2d8
+        let D8plus8minus8plusD8 = Dice("d8+8-8+d8")
+        let negative8plusD8plusD8plus8 = Dice("-8+d8+d8+8")
+        let D8plus8plusD8minus8 = Dice("d8+8+d8-8")
+        let negative8plusD8plus8plusD8 = Dice("-8+d8+8+d8")
+        
+        //20
+        let D10plus10plus10minusD10 = Dice("d10+10+10-d10")
+        let _10plusD10minusD10plus10 = Dice("10+d10-d10+10")
+        let D10plus10minusD10plus10 = Dice("d10+10-d10+10")
+        let _10plusD10plus10minusD10 = Dice("10+d10+10-d10")
+        
+        
+        XCTAssertNotNil(D6plus6plus6plusD6)
+        XCTAssertNotNil(_6plusD6plusD6plus6)
+        XCTAssertNotNil(D6plus6plusD6plus6)
+        XCTAssertNotNil(_6plusD6plus6plusD6)
+        XCTAssertNotNil(D4minus4minus4plusD4)
+        XCTAssertNotNil(negative4plusD4plusD4minus4)
+        XCTAssertNotNil(D4minus4plusD4minus4)
+        XCTAssertNotNil(negative4plusD4minus4plusD4)
+        XCTAssertNotNil(D8plus8minus8plusD8)
+        XCTAssertNotNil(negative8plusD8plusD8plus8)
+        XCTAssertNotNil(D8plus8plusD8minus8)
+        XCTAssertNotNil(negative8plusD8plus8plusD8)
+        XCTAssertNotNil(D10plus10plus10minusD10)
+        XCTAssertNotNil(_10plusD10minusD10plus10)
+        XCTAssertNotNil(D10plus10minusD10plus10)
+        XCTAssertNotNil(_10plusD10plus10minusD10)
+        
+        
+        XCTAssertEqual(D6plus6plus6plusD6, Dice(dice: [Die.d6, Die.d6], withModifier: 12))
+        XCTAssertEqual(_6plusD6plusD6plus6, Dice(dice: [Die.d6, Die.d6], withModifier: 12))
+        XCTAssertEqual(D6plus6plusD6plus6, Dice(dice: [Die.d6, Die.d6], withModifier: 12))
+        XCTAssertEqual(_6plusD6plus6plusD6, Dice(dice: [Die.d6, Die.d6], withModifier: 12))
+        
+        XCTAssertEqual(D4minus4minus4plusD4, Dice(dice: [Die.d4, Die.d4], withModifier: -8))
+        XCTAssertEqual(negative4plusD4plusD4minus4, Dice(dice: [Die.d4, Die.d4], withModifier: -8))
+        XCTAssertEqual(D4minus4plusD4minus4, Dice(dice: [Die.d4, Die.d4], withModifier: -8))
+        XCTAssertEqual(negative4plusD4minus4plusD4, Dice(dice: [Die.d4, Die.d4], withModifier: -8))
+        
+        XCTAssertEqual(D8plus8minus8plusD8, Dice(dice: [Die.d8, Die.d8], withModifier: 0))
+        XCTAssertEqual(negative8plusD8plusD8plus8, Dice(dice: [Die.d8, Die.d8], withModifier: 0))
+        XCTAssertEqual(D8plus8plusD8minus8, Dice(dice: [Die.d8, Die.d8], withModifier: 0))
+        XCTAssertEqual(negative8plusD8plus8plusD8, Dice(dice: [Die.d8, Die.d8], withModifier: 0))
+        
+        XCTAssertEqual(D10plus10plus10minusD10, Dice(dice: [], withModifier: 20))
+        XCTAssertEqual(_10plusD10minusD10plus10, Dice(dice: [], withModifier: 20))
+        XCTAssertEqual(D10plus10minusD10plus10, Dice(dice: [], withModifier: 20))
+        XCTAssertEqual(_10plusD10plus10minusD10, Dice(dice: [], withModifier: 20))
     }
     
     func testInvalidStringParsing() {

--- a/Tests/DiceKitTests/DiceTests.swift
+++ b/Tests/DiceKitTests/DiceTests.swift
@@ -110,7 +110,32 @@ final class DiceTests: XCTestCase {
     }
     
     func testSingleDieAndSingleModifierStringParsing() {
+        //Sucessfuls
+        let d6plus6_1 = Dice("d6+6")
+        let d6plus6_2 = Dice("6+d6")
+        let d4minus4_1 = Dice("d4-4")
+        let d4minus4_2 = Dice("-4+d4")
         
+        //Unsucessfuls - NIL
+        let negatived8plus8_1 = Dice("-d8+8")
+        let negatived8plus8_2 = Dice("8-d8")
+        let negatived8minus8_1 = Dice("-d8-8")
+        let negatived8minus8_2 = Dice("-8-d8")
+        
+        XCTAssertNotNil(d6plus6_1)
+        XCTAssertNotNil(d6plus6_2)
+        XCTAssertNotNil(d4minus4_1)
+        XCTAssertNotNil(d4minus4_2)
+        
+        XCTAssertNil(negatived8plus8_1)
+        XCTAssertNil(negatived8plus8_2)
+        XCTAssertNil(negatived8minus8_1)
+        XCTAssertNil(negatived8minus8_2)
+        
+        XCTAssertEqual(d6plus6_1, Dice(dice: [Die.d6], withModifier: 6))
+        XCTAssertEqual(d6plus6_2, Dice(dice: [Die.d6], withModifier: 6))
+        XCTAssertEqual(d4minus4_1, Dice(dice: [Die.d4], withModifier: -4))
+        XCTAssertEqual(d4minus4_2, Dice(dice: [Die.d4], withModifier: -4))
     }
     
     func testMultipleDieAndMultipleModifierStringParsing() {

--- a/Tests/DiceKitTests/DieTests.swift
+++ b/Tests/DiceKitTests/DieTests.swift
@@ -39,6 +39,28 @@ final class DieTests: XCTestCase {
         XCTAssertEqual(d12_3, Die.d12)
     }
     
+    func testInvalidStringParsing() {
+        // Assorted
+        XCTAssertNil(Die("")) // empty
+        XCTAssertNil(Die("d")) // d without value
+        XCTAssertNil(Die("q1")) // other that d in front
+        XCTAssertNil(Die("d1b")) // binary (other form with d)
+        XCTAssertNil(Die("1o")) // octal (other forw without d)
+        XCTAssertNil(Die("one")) // spelled out
+        XCTAssertNil(Die("A")) // hexadecimal
+        XCTAssertNil(Die("DiceKit")) // string
+        
+        //Negative
+        XCTAssertNil(Die("-6"))
+        XCTAssertNil(Die("-d6"))
+        XCTAssertNil(Die("d-6"))
+        
+        //Positive
+        XCTAssertNil(Die("+6"))
+        XCTAssertNil(Die("+d6"))
+        XCTAssertNil(Die("d+6"))
+    }
+    
     func testSidesProperty() {
         for i in 1...100 {
             let die = Die(sides: i)!

--- a/Tests/DiceKitTests/DieTests.swift
+++ b/Tests/DiceKitTests/DieTests.swift
@@ -11,6 +11,34 @@ final class DieTests: XCTestCase {
         XCTAssertNotNil(d6)
     }
     
+    func testSingleDigitStringParsing() {
+        let d6_1 = Die("6")
+        let d6_2 = Die("d6")
+        let d6_3 = Die("D6")
+        
+        XCTAssertNotNil(d6_1)
+        XCTAssertNotNil(d6_2)
+        XCTAssertNotNil(d6_3)
+        
+        XCTAssertEqual(d6_1, Die.d6)
+        XCTAssertEqual(d6_2, Die.d6)
+        XCTAssertEqual(d6_3, Die.d6)
+    }
+    
+    func testMultipleDigitStringParsing() {
+        let d12_1 = Die("12")
+        let d12_2 = Die("d12")
+        let d12_3 = Die("D12")
+        
+        XCTAssertNotNil(d12_1)
+        XCTAssertNotNil(d12_2)
+        XCTAssertNotNil(d12_3)
+        
+        XCTAssertEqual(d12_1, Die.d12)
+        XCTAssertEqual(d12_2, Die.d12)
+        XCTAssertEqual(d12_3, Die.d12)
+    }
+    
     func testSidesProperty() {
         for i in 1...100 {
             let die = Die(sides: i)!

--- a/Tests/DiceKitTests/XCTestManifests.swift
+++ b/Tests/DiceKitTests/XCTestManifests.swift
@@ -8,6 +8,7 @@ extension DiceKitTests {
 
 extension DiceTests {
     static let __allTests = [
+        ("testInvalidStringParsing", testInvalidStringParsing),
         ("testMultipleDieAndMultipleModifierStringParsing", testMultipleDieAndMultipleModifierStringParsing),
         ("testMultipleModifierStringParsing", testMultipleModifierStringParsing),
         ("testMultipleRepeatedDieStringParsing", testMultipleRepeatedDieStringParsing),

--- a/Tests/DiceKitTests/XCTestManifests.swift
+++ b/Tests/DiceKitTests/XCTestManifests.swift
@@ -23,6 +23,7 @@ extension DieTests {
         ("testCopying", testCopying),
         ("testEquatable", testEquatable),
         ("testInitialization", testInitialization),
+        ("testInvalidStringParsing", testInvalidStringParsing),
         ("testMaximumResultProperty", testMaximumResultProperty),
         ("testMinimumResultProperty", testMinimumResultProperty),
         ("testMultipleDigitStringParsing", testMultipleDigitStringParsing),

--- a/Tests/DiceKitTests/XCTestManifests.swift
+++ b/Tests/DiceKitTests/XCTestManifests.swift
@@ -9,8 +9,9 @@ extension DiceKitTests {
 extension DiceTests {
     static let __allTests = [
         ("testMultipleDieAndMultipleModifierStringParsing", testMultipleDieAndMultipleModifierStringParsing),
-        ("testMultipleDieStringParsing", testMultipleDieStringParsing),
         ("testMultipleModifierStringParsing", testMultipleModifierStringParsing),
+        ("testMultipleRepeatedDieStringParsing", testMultipleRepeatedDieStringParsing),
+        ("testMultipleSeparateDieStringParsing", testMultipleSeparateDieStringParsing),
         ("testSingleDieAndSingleModifierStringParsing", testSingleDieAndSingleModifierStringParsing),
         ("testSingleDieStringParsing", testSingleDieStringParsing),
         ("testSingleModifierStringParsing", testSingleModifierStringParsing),

--- a/Tests/DiceKitTests/XCTestManifests.swift
+++ b/Tests/DiceKitTests/XCTestManifests.swift
@@ -8,7 +8,12 @@ extension DiceKitTests {
 
 extension DiceTests {
     static let __allTests = [
-        ("testExample", testExample),
+        ("testMultipleDieAndMultipleModifierStringParsing", testMultipleDieAndMultipleModifierStringParsing),
+        ("testMultipleDieStringParsing", testMultipleDieStringParsing),
+        ("testMultipleModifierStringParsing", testMultipleModifierStringParsing),
+        ("testSingleDieAndSingleModifierStringParsing", testSingleDieAndSingleModifierStringParsing),
+        ("testSingleDieStringParsing", testSingleDieStringParsing),
+        ("testSingleModifierStringParsing", testSingleModifierStringParsing),
     ]
 }
 
@@ -20,8 +25,10 @@ extension DieTests {
         ("testInitialization", testInitialization),
         ("testMaximumResultProperty", testMaximumResultProperty),
         ("testMinimumResultProperty", testMinimumResultProperty),
+        ("testMultipleDigitStringParsing", testMultipleDigitStringParsing),
         ("testRolling", testRolling),
         ("testSidesProperty", testSidesProperty),
+        ("testSingleDigitStringParsing", testSingleDigitStringParsing),
         ("testStaticVarDice", testStaticVarDice),
     ]
 }


### PR DESCRIPTION
This PR adds the ability to construct `Die` and `Dice` objects from strings:
```swift
print(Die("6")) // Optional("A six sided die")
print(Die("d6")) // Optional("A six sided die")
print(Die("DiceKit")) // nil

print(Dice("d6").debugDescription) // Optional("d6")
print(Dice("8d12+5+4d6-3").debugDescription // Optional("4d6+8d12+2")
```

Closes #5