### PR TITLE
Fixed bug in Die Swift: 'sides' instead of hard coded '6'

### DIFF
--- a/Sources/DiceKit/Die.swift
+++ b/Sources/DiceKit/Die.swift
@@ -69,7 +69,7 @@ extension Die: Rollable {
     /// - Returns: A random value from `1` to `sides`.
     public func roll() -> Roll {
         #if swift(>=4.2)
-        return Roll.random(in: 1...6)
+        return Roll.random(in: 1...sides)
         #else
         #if os(macOS)
         //macOS


### PR DESCRIPTION
I fixed a small bug in Die.swift, function roll(). Instead of the variable 'sides' the hard coded '6' was used. 

This is my very first contribution on GitHub. Hope, I did everything right?