### PR TITLE
Version 0.14.2: Dice Operators Fix & Guidelines

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at 30577766+Samasaur1@users.noreply.github.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -174,6 +174,8 @@ What follows is a list of styles that you should follow.
   let some_constant = Some_class()
   ```
 
+* Use argument labels liberally
+
 * If you have any questions, do your best and ask in your PR (or in some other way)
 
 ## Attribution

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,185 @@
+# Contributing to DiceKit
+
+First off, thanks for taking the time to contribute!
+
+This document is a set of guidelines for contributing to DiceKit. Feel free to propose changes if you disagree.
+
+## Table of Contents
+
+* [Code of Conduct](#code-of-conduct)
+* [General Guidelines](#general-guidelines)
+  * [Issues](#issues)
+  * [Pull Requests](#pull-requests)
+* [Getting Started](#getting-started)
+* [How Can I Contribute?](#how-can-i-contribute)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Fixing Bugs](#fixing-bugs)
+  * [Fixing Formatting](#fixing-formatting)
+  * [Adding New Features](#adding-new-features)
+  * [Adding Documentation](#adding-documentation)
+  * [Labeled Issues](#labeled-issues)
+* [Styleguide](#styleguide)
+  * [Git Commit Messages](#git-commit-messages)
+  * [Swift](#swift)
+* [Attribution](#attribution)
+
+
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [DiceKit Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [30577766+Samasaur1@users.noreply.github.com](mailto:30577766+Samasaur1@users.noreply.github.com).
+
+## General Guidelines
+
+These are some general guidelines to contributing. Read below if you need more information.
+
+### Issues
+
+* If there is an issue template that matches what you are trying to do, use it
+* You can always make issues before pull requests
+* Feel free to help others in issues, but you should still follow the Code of Conduct (obviously)
+
+### Pull Requests
+
+* **Please make all pull requests against the `development` branch.**
+* If you want to fix an issue, say so on the issue
+* Don't attempt to fix issues that others have claimed
+  * If they don't appear to be working on it, ask them on the issue. If they say you can take over or they don't respond, go ahead.
+  * When in doubt, **@mention** me by including `@Samasaur1` in your message.
+
+## Getting Started
+
+Do the following:
+
+```bash
+$ git clone https://github.com/Samasaur1/DiceKit.git
+$ cd DiceKit
+$ swift package update
+$ swift build
+$ swift package generate-xcodeproj
+$ open DiceKit.xcodeproj
+```
+
+This will open an Xcode project consisting of DiceKit. We suggest you then build the project using ⌘B (command-B) or Product→Build.
+
+To see what you should do, head on down to [How Can I Contribute?](#how-can-i-contribute)
+
+## How Can I Contribute?
+
+There are a bunch of ways you can contribute to DiceKit—and you don't even need to write any code if you don't want to.
+
+### Reporting Bugs
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/Samasaur1/DiceKit/issues).
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/Samasaur1/DiceKit/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+* **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
+* **Which version of DiceKit are you using?** If you are using the Swift Package Manager, you might need to check what the latest version is (please don't say "latest"). If you are using a specific commit, give that hash. If you are using a branch, find the hash of the latest commit on that branch and use that.
+* **What's the name and version of the OS you're using**?
+
+### Fixing Bugs
+
+1. Open a new GitHub pull request with the patch.
+2. Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+### Fixing Formatting
+
+Please make this clear by prefixing your PR title with `Formatting:`. For example, `Fix example formatting` would become `Formatting: Fix example formatting`.
+
+### Adding New Features
+
+We recommend creating a new issue to propose your feature before you create a pull request. That way, if we don't feel it fits the spirit of the project, you haven't spent time on it.
+
+### Adding Documentation
+
+If you decide to do this, thank you. Keep in mind that we may request changes in order to ensure that the documentation is up to our standards, but we will never refuse a docuementation pull request outright.
+
+### Labeled Issues
+
+Unsure where to begin contributing to DiceKit? You can start by looking through these `good first issue` and `help wanted` issues:
+
+- [Beginner issues][https://github.com/Samasaur1/DiceKit/issues?utf8=✓&q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22] - issues which should only require a few lines of code, and a test or two.
+- [Help wanted issues][https://github.com/Samasaur1/DiceKit/issues?utf8=✓&q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22] - issues which are more difficult for me, but that you may find easy.
+
+## Styleguide
+
+What follows is a list of styles that you should follow.
+
+### Git Commit Messages
+
+* Use the present tense ("Add feature" not "Added feature")
+* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+* Limit the first line to 72 characters or less
+* Reference issues and pull requests liberally after the first line
+
+### Swift
+
+* Use an indent of 4 spaces (Xcode automatically replaces tabs with 4 spaces)
+
+* Whenever you have a code block surrounded by braces, even if it's one line, format it like this,:
+
+  ```swift
+  if condition {
+      print(true)
+  }
+  ```
+
+  instead of like this:
+
+  ```swift
+  if condition { print(true) }
+  ```
+
+* Don't do this:
+
+  ```swift
+  let num1: Int              = 0
+  let num2: Double           = 0
+  let numberNumberThree: Int = 0
+  let _4                     = 0
+  ```
+
+* Please use `if-let`/`guard-let` instead of force-unwrapping (i.e. `!`). So do this:
+
+  ```swift
+  if let value = optional {
+      print(value)
+  }
+  
+  // or
+  
+  guard let value = optional else {
+      return
+  }
+  print(value)
+  ```
+
+  instead of this:
+
+  ```swift
+  print(value!)
+  ```
+
+* Please use uppercase class/struct/protocol/enum names, along with lowercase method and property names
+
+* Use upper/lower camel case, not snake case. For example:
+
+  ```swift
+  // Good:
+  let someConstant = SomeClass()
+  
+  // Bad:
+  let some_constant = Some_class()
+  ```
+
+* If you have any questions, do your best and ask in your PR (or in some other way)
+
+## Attribution
+
+This contributing guide was adapted from both the [Atom contributing guide](https://github.com/atom/atom/blob/master/CONTRIBUTING.md) and the [Ruby on Rails contributing guide](https://github.com/rails/rails/blob/master/CONTRIBUTING.md).
+
+***
+
+If you read down to here, you've gotta be very determined. We hope you decide to contribute!

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.14.1
+module_version: 0.14.2
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -460,7 +460,7 @@ extension Dice {
             }
         }
         dice.append(rhs)
-        return Dice(dice: dice)
+        return Dice(dice: dice, withModifier: lhs.modifier)
     }
     public static func + (lhs: Die, rhs: Dice) -> Dice {
         var dice: [Die] = []
@@ -470,7 +470,7 @@ extension Dice {
             }
         }
         dice.append(lhs)
-        return Dice(dice: dice)
+        return Dice(dice: dice, withModifier: rhs.modifier)
     }
     
     public static func + (lhs: Dice, rhs: Dice) -> Dice {
@@ -485,7 +485,7 @@ extension Dice {
                 dice.append(d.copy())
             }
         }
-        return Dice(dice: dice)
+        return Dice(dice: dice, withModifier: rhs.modifier + lhs.modifier)
     }
     
     public static func + (lhs: Dice, rhs: Int) -> Dice {
@@ -495,7 +495,7 @@ extension Dice {
                 dice.append(d.copy())
             }
         }
-        return Dice(dice: dice, withModifier: rhs)
+        return Dice(dice: dice, withModifier: lhs.modifier + rhs)
     }
     public static func + (lhs: Int, rhs: Dice) -> Dice {
         var dice: [Die] = []
@@ -504,7 +504,7 @@ extension Dice {
                 dice.append(d.copy())
             }
         }
-        return Dice(dice: dice, withModifier: lhs)
+                return Dice(dice: dice, withModifier: lhs + rhs.modifier)
     }
     public static func + (lhs: Dice, rhs: (die: Die, count: Int)) -> Dice {
         return lhs + (rhs.die * rhs.count)
@@ -517,16 +517,16 @@ extension Dice {
     }
     public static func * (lhs: Dice, rhs: Int) -> Dice {
         var dice = lhs.copy()
-        for (die, _) in lhs.dice {
-            dice += die * (rhs - 1)
+        for (die, count) in lhs.dice {
+            dice += die * (count * (rhs - 1))
         }
         dice += lhs.modifier * (rhs - 1)
         return dice
     }
     public static func * (lhs: Int, rhs: Dice) -> Dice {
         var dice = rhs.copy()
-        for (die, _) in rhs.dice {
-            dice += die * (lhs - 1)
+        for (die, count) in rhs.dice {
+            dice += die * ((lhs - 1) * count)
         }
         dice += rhs.modifier * (lhs - 1)
         return dice


### PR DESCRIPTION
This PR closes #46, merging the changes outlined in #47. It also contributes towards #14, adding the `CONTRIBUTING.md` file.

Fix incorrect dice operators (#46)

Next Steps:

1. Wait for CI
1. Bump version
1. Wait for CI
1. Merge
1. `git checkout master`
1. `git pull`
1. `git tag -s v0.14.2 -m "Version 0.14.2: Dice Operators Fix & Guidelines"`
1. `git push --tags`
1. `git checkout development`
1. `git pull`
1. `git rebase master`
1. `git push`