### PR TITLE
Add average result and canReach function (#16, #8)

### DIFF
--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -346,6 +346,34 @@ extension Dice: Rollable {
         }
         return total
     }
+    
+    /// Determines whether this `Dice` object can reach the target `Roll` using the given comparison type.
+    ///
+    /// - Parameters:
+    ///   - target: The target to check reachibility for.
+    ///   - comparisonType: The comparison to use when checking reachibility.
+    /// - Returns: Whether or not this `Dice` object can reach the target, using the given comparison.
+    ///
+    /// - Since: UPDATE_ME
+    public func canReach(_ target: Roll, _ comparisonType: RollComparison) -> Bool {
+        switch comparisonType {
+        case .orHigher:
+            return maximumResult >= target
+        case .exactly:
+            if modifier > target {
+                return false
+            }
+            if maximumResult < target {
+                return false
+            }
+            if minimumResult > target {
+                return false
+            }
+            return true
+        case .orLower:
+            return minimumResult <= target
+        }
+    }
 }
 
 extension Dice: Equatable {

--- a/Sources/DiceKit/DiceKit.swift
+++ b/Sources/DiceKit/DiceKit.swift
@@ -81,7 +81,7 @@ public enum MultipleRollResult {
     /// For example, if the rolls were 2, 8, 6, 4, and 10, and `amountToDrop` is 3, then the result would be 12 (2 + 4 + 6)
     case dropHigh(amountToDrop: Int)
 }
-
+#if swift(>=4.2)
 /// An enum representing a comparison between two `Roll`s.
 ///
 /// - Since: UPDATE_ME
@@ -93,6 +93,19 @@ public enum RollComparison: CaseIterable {
     /// If it is exactly equal to the target.
     case exactly
 }
+#else
+/// An enum representing a comparison between two `Roll`s.
+///
+/// - Since: UPDATE_ME
+public enum RollComparison {
+    /// If it is greater than or equal to the target.
+    case orHigher
+    /// If it is less than or equal to the target.
+    case orLower
+    /// If it is exactly equal to the target.
+    case exactly
+}
+#endif
 
 internal extension Array where Element == Roll {
     internal var sum: Roll {

--- a/Sources/DiceKit/DiceKit.swift
+++ b/Sources/DiceKit/DiceKit.swift
@@ -30,6 +30,14 @@ public protocol Rollable {
     ///
     /// - Since: 0.2.0
     var maximumResult: Roll { get }
+    
+    /// Determines whether or not this object can reach the target Roll, compared by the given comparison.
+    ///
+    /// - Parameters:
+    ///   - target: The target to check reachibility for.
+    ///   - comparisonType: The method of checking reachibility.
+    /// - Returns: Whether or not this object can reach the target using the given method of comparison.
+    func canReach(_ target: Roll, _ comparisonType: RollComparison) -> Bool
 }
 
 /// An enum representing the type of result to return from rolling multiple times.
@@ -72,6 +80,18 @@ public enum MultipleRollResult {
     ///
     /// For example, if the rolls were 2, 8, 6, 4, and 10, and `amountToDrop` is 3, then the result would be 12 (2 + 4 + 6)
     case dropHigh(amountToDrop: Int)
+}
+
+/// An enum representing a comparison between two `Roll`s.
+///
+/// - Since: UPDATE_ME
+public enum RollComparison {
+    /// If it is greater than or equal to the target.
+    case orHigher
+    /// If it is less than or equal to the target.
+    case orLower
+    /// If it is exactly equal to the target.
+    case exactly
 }
 
 internal extension Array where Element == Roll {

--- a/Sources/DiceKit/DiceKit.swift
+++ b/Sources/DiceKit/DiceKit.swift
@@ -85,7 +85,7 @@ public enum MultipleRollResult {
 /// An enum representing a comparison between two `Roll`s.
 ///
 /// - Since: UPDATE_ME
-public enum RollComparison {
+public enum RollComparison: CaseIterable {
     /// If it is greater than or equal to the target.
     case orHigher
     /// If it is less than or equal to the target.

--- a/Sources/DiceKit/Die.swift
+++ b/Sources/DiceKit/Die.swift
@@ -152,6 +152,25 @@ extension Die: Rollable {
     public var maximumResult: Roll {
         return sides
     }
+    
+    /// Determines whether this `Die` can reach the target `Roll` using the given comparison type.
+    ///
+    /// - Parameters:
+    ///   - target: The target to check reachibility for.
+    ///   - comparisonType: The comparison to use when checking reachibility.
+    /// - Returns: Whether or not this die can reach the target, using the given comparison.
+    ///
+    /// - Since: UPDATE_ME
+    public func canReach(_ target: Roll, _ comparisonType: RollComparison) -> Bool {
+        switch comparisonType {
+        case .orHigher:
+            return maximumResult >= target
+        case .exactly:
+            return minimumResult <= target && maximumResult >= target
+        case .orLower:
+            return minimumResult <= target
+        }
+    }
 }
 
 extension Die: Equatable {

--- a/Tests/DiceKitTests/DieTests.swift
+++ b/Tests/DiceKitTests/DieTests.swift
@@ -102,6 +102,20 @@ final class DieTests: XCTestCase {
         }
     }
     
+    func testCanReach() {
+        let d6 = Die.d6
+        
+        for target in 1...6 {
+            for type in RollComparison.allCases {
+                XCTAssertTrue(d6.canReach(target, type))
+            }
+        }
+        
+        XCTAssertTrue(d6.canReach(8, .orLower))
+        XCTAssertFalse(d6.canReach(8, .exactly))
+        XCTAssertFalse(d6.canReach(8, .orHigher))
+    }
+    
     func testEquatable() {
         let d6 = Die.d6
         let initializedD6 = Die(sides: 6)!

--- a/Tests/DiceKitTests/DieTests.swift
+++ b/Tests/DiceKitTests/DieTests.swift
@@ -106,9 +106,15 @@ final class DieTests: XCTestCase {
         let d6 = Die.d6
         
         for target in 1...6 {
+            #if swift(>=4.2)
             for type in RollComparison.allCases {
                 XCTAssertTrue(d6.canReach(target, type))
             }
+            #else
+            for type in [RollComparison.orLower, RollComparison.exactly, RollComparison.orHigher] {
+                XCTAssertTrue(d6.canReach(target, type))
+            }
+            #endif
         }
         
         XCTAssertTrue(d6.canReach(8, .orLower))

--- a/Tests/DiceKitTests/XCTestManifests.swift
+++ b/Tests/DiceKitTests/XCTestManifests.swift
@@ -23,6 +23,7 @@ extension DiceTests {
 extension DieTests {
     static let __allTests = [
         ("testComparable", testComparable),
+        ("testCanReach", testCanReach),
         ("testCopying", testCopying),
         ("testEquatable", testEquatable),
         ("testInitialization", testInitialization),

--- a/Tests/DiceKitTests/XCTestManifests.swift
+++ b/Tests/DiceKitTests/XCTestManifests.swift
@@ -22,8 +22,8 @@ extension DiceTests {
 
 extension DieTests {
     static let __allTests = [
-        ("testComparable", testComparable),
         ("testCanReach", testCanReach),
+        ("testComparable", testComparable),
         ("testCopying", testCopying),
         ("testEquatable", testEquatable),
         ("testInitialization", testInitialization),


### PR DESCRIPTION
This PR merges the current status of the `possibility-and-probability` (34f5565084a5abbdc1205210e8b81cfee5ed1f61) branch into `development`. It includes the `averageResult` property, which returns the average result of a `Die` or `Dice`, along with the `canReach(_:_:)` function, which determines whether or not a `Die` or `Dice` *can reach* a target.

What still needs to happen?
* Tests for `averageResult`
* Changing the `Since` from `UPDATE_ME` to `0.15.0`

These can both happen on `development`