### PR TITLE
Add average result and canReach function (#16, #8, #50)

### DIFF
--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -346,6 +346,47 @@ extension Dice: Rollable {
         }
         return total
     }
+  
+    /// The average result from using the `roll()` method.
+    /// It is calculated with double numbers to avoid rounding errors.
+    ///
+    /// - Since: UPDATE_ME
+    public var averageResult: Roll {
+      var doubleAverage: Double = 0
+      for (die,count) in self.dice {
+        doubleAverage += Double(count) * die.doubleAverageResult
+      }
+      let average = Int(doubleAverage.rounded())
+      return average + self.modifier
+    }
+    
+    /// Determines whether this `Dice` object can reach the target `Roll` using the given comparison type.
+    ///
+    /// - Parameters:
+    ///   - target: The target to check reachibility for.
+    ///   - comparisonType: The comparison to use when checking reachibility.
+    /// - Returns: Whether or not this `Dice` object can reach the target, using the given comparison.
+    ///
+    /// - Since: UPDATE_ME
+    public func canReach(_ target: Roll, _ comparisonType: RollComparison) -> Bool {
+        switch comparisonType {
+        case .orHigher:
+            return maximumResult >= target
+        case .exactly:
+            if modifier > target {
+                return false
+            }
+            if maximumResult < target {
+                return false
+            }
+            if minimumResult > target {
+                return false
+            }
+            return true
+        case .orLower:
+            return minimumResult <= target
+        }
+    }
 }
 
 extension Dice: Equatable {

--- a/Sources/DiceKit/DiceKit.swift
+++ b/Sources/DiceKit/DiceKit.swift
@@ -30,6 +30,19 @@ public protocol Rollable {
     ///
     /// - Since: 0.2.0
     var maximumResult: Roll { get }
+  
+    /// The average result from using the `roll()` method.
+    ///
+    /// - Since: UPDATE_ME
+    var averageResult: Roll { get }
+    
+    /// Determines whether or not this object can reach the target Roll, compared by the given comparison.
+    ///
+    /// - Parameters:
+    ///   - target: The target to check reachibility for.
+    ///   - comparisonType: The method of checking reachibility.
+    /// - Returns: Whether or not this object can reach the target using the given method of comparison.
+    func canReach(_ target: Roll, _ comparisonType: RollComparison) -> Bool
 }
 
 /// An enum representing the type of result to return from rolling multiple times.
@@ -73,6 +86,31 @@ public enum MultipleRollResult {
     /// For example, if the rolls were 2, 8, 6, 4, and 10, and `amountToDrop` is 3, then the result would be 12 (2 + 4 + 6)
     case dropHigh(amountToDrop: Int)
 }
+#if swift(>=4.2)
+/// An enum representing a comparison between two `Roll`s.
+///
+/// - Since: UPDATE_ME
+public enum RollComparison: CaseIterable {
+    /// If it is greater than or equal to the target.
+    case orHigher
+    /// If it is less than or equal to the target.
+    case orLower
+    /// If it is exactly equal to the target.
+    case exactly
+}
+#else
+/// An enum representing a comparison between two `Roll`s.
+///
+/// - Since: UPDATE_ME
+public enum RollComparison {
+    /// If it is greater than or equal to the target.
+    case orHigher
+    /// If it is less than or equal to the target.
+    case orLower
+    /// If it is exactly equal to the target.
+    case exactly
+}
+#endif
 
 internal extension Array where Element == Roll {
     internal var sum: Roll {

--- a/Sources/DiceKit/Die.swift
+++ b/Sources/DiceKit/Die.swift
@@ -152,6 +152,40 @@ extension Die: Rollable {
     public var maximumResult: Roll {
         return sides
     }
+  
+    /// The exact (double) average result from using the `roll()` method.
+    /// This is used in the Dice method to avoid rounding errors.
+    ///
+    /// - Since: UPDATE_ME
+    public var doubleAverageResult: Double {
+      return Double(sides + 1) / 2
+    }
+  
+    /// The average result from using the `roll()` method.
+    ///
+    /// - Since: UPDATE_ME
+    public var averageResult: Roll {
+      return   Int(doubleAverageResult.rounded())
+    }
+    
+    /// Determines whether this `Die` can reach the target `Roll` using the given comparison type.
+    ///
+    /// - Parameters:
+    ///   - target: The target to check reachibility for.
+    ///   - comparisonType: The comparison to use when checking reachibility.
+    /// - Returns: Whether or not this die can reach the target, using the given comparison.
+    ///
+    /// - Since: UPDATE_ME
+    public func canReach(_ target: Roll, _ comparisonType: RollComparison) -> Bool {
+        switch comparisonType {
+        case .orHigher:
+            return maximumResult >= target
+        case .exactly:
+            return minimumResult <= target && maximumResult >= target
+        case .orLower:
+            return minimumResult <= target
+        }
+    }
 }
 
 extension Die: Equatable {

--- a/Tests/DiceKitTests/DieTests.swift
+++ b/Tests/DiceKitTests/DieTests.swift
@@ -102,6 +102,26 @@ final class DieTests: XCTestCase {
         }
     }
     
+    func testCanReach() {
+        let d6 = Die.d6
+        
+        for target in 1...6 {
+            #if swift(>=4.2)
+            for type in RollComparison.allCases {
+                XCTAssertTrue(d6.canReach(target, type))
+            }
+            #else
+            for type in [RollComparison.orLower, RollComparison.exactly, RollComparison.orHigher] {
+                XCTAssertTrue(d6.canReach(target, type))
+            }
+            #endif
+        }
+        
+        XCTAssertTrue(d6.canReach(8, .orLower))
+        XCTAssertFalse(d6.canReach(8, .exactly))
+        XCTAssertFalse(d6.canReach(8, .orHigher))
+    }
+    
     func testEquatable() {
         let d6 = Die.d6
         let initializedD6 = Die(sides: 6)!

--- a/Tests/DiceKitTests/XCTestManifests.swift
+++ b/Tests/DiceKitTests/XCTestManifests.swift
@@ -22,6 +22,7 @@ extension DiceTests {
 
 extension DieTests {
     static let __allTests = [
+        ("testCanReach", testCanReach),
         ("testComparable", testComparable),
         ("testCopying", testCopying),
         ("testEquatable", testEquatable),


### PR DESCRIPTION
> This PR merges the current status of the `possibility-and-probability` (34f5565084a5abbdc1205210e8b81cfee5ed1f61) branch into `development`. It includes the `averageResult` property, which returns the average result of a `Die` or `Dice`, along with the `canReach(_:_:)` function, which determines whether or not a `Die` or `Dice` *can reach* a target.
>
> What still needs to happen?
> * Tests for `averageResult`
> * Changing the `Since` from `UPDATE_ME` to `0.15.0`
>
> These can both happen on `development`

This PR adds the `averageResult` property and the `canReach(_:_:)` function.

1. Write tests for `averageResult`
1. Change the `Since` from `UPDATE_ME` to `0.15.0`
1. Wait for CI
1. Bump version
1. Wait for CI
1. Merge
1. `git checkout master`
1. `git pull`
1. `git tag -s v0.14.2 -m "Version 0.14.2: Dice Operators Fix & Guidelines"`
1. `git push --tags`
1. `git checkout development`
1. `git pull`
1. `git rebase master`
1. `git push`