### PR TITLE
Version 0.16.1: Update Swift 5 CI to Xcode 10.2

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.16.0
+module_version: 0.16.1
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,22 +10,23 @@ osx_image: xcode10
 
 env:
 - SWIFT_VERSION=4.2.4
+- SWIFT_VERSION=5.0.1
 
 jobs:
   include:
-  - osx_image: xcode10
+  - osx_image: xcode10.2
     os: linux
     env: SWIFT_VERSION=5.0.1
     script: swift test
   - stage: test
     if: branch != master OR type = pull_request
-    osx_image: xcode10
+    osx_image: xcode10.2
     os: osx
     env: SWIFT_VERSION=5.0.1
     script: swift test
   - stage: deploy
     if: branch = master AND type = push
-    osx_image: xcode10
+    osx_image: xcode10.2
     os: osx
     env: SWIFT_VERSION=5.0.1
     script: bash .deploy-docs.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
+## [0.16.1] - 2019-06-24
+### Added
+- Testing on Swift 5.0.1 and Xcode 10.2
+
+### Fixed
+- Auto-deploying docs
+
 ## [0.16.0] - 2019-06-24
 ### Added
 - `CustomDie`
@@ -134,6 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Rollable`: a protocol for anything that is rollable
 
 [Upcoming]: https://github.com/Samasaur1/DiceKit/compare/development
+[0.16.1]: https://github.com/Samasaur1/DiceKit/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/Samasaur1/DiceKit/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Samasaur1/DiceKit/compare/v0.14.0...v0.15.0
 [0.14.1]: https://github.com/Samasaur1/DiceKit/compare/v0.14.0...v0.14.1


### PR DESCRIPTION
Here's what's new:
- Fixes CI for deploying docs and tests on Swift 5.0.1/Xcode 10.2

Here's what has to happen:
- [x] Ensure the changelog has everything new that is being added
- [x] Bump version
1. Wait for CI
1. Merge
1. `git checkout master`
1. `git pull`
1. `git tag -s v0.16.0 -m "Version 0.16.0: Custom dice, weighted dice, a changelog, errors, and Swift 4.2+ only"`
1. `git push --tags`
1. `git checkout development`
1. `git pull`
1. `git rebase master`
1. `git push`