### PR TITLE
Version 0.18.1: Release script & documentation

### DIFF
--- a/.deploy-docs.sh
+++ b/.deploy-docs.sh
@@ -5,7 +5,7 @@ gem install jazzy
 rm -rf docs
 rm -rf DiceKit.xcodeproj
 swift package generate-xcodeproj
-jazzy
+jazzy -x -target,DiceKit
 cd docs
 echo 'section > section > p > img { margin-top: 4em; margin-right: 2em; }' >> css/jazzy.css
 git config --global user.name "Documentation Bot"

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.18.0
+module_version: 0.18.1
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
+## [0.18.1] - 2019-08-22
+### Fixed
+- The release script has been fixed (closes #67)
+- The automatic documentation has been fixed
+
 ## [0.18.0] - 2019-08-04
 ### Added
 - Add release.py and updateVersion.py scripts
@@ -187,6 +192,7 @@ Update .travis.yml in case https://swiftenv.fuller.li/install.sh is down/has no 
 - `Rollable`: a protocol for anything that is rollable
 
 [Upcoming]: https://github.com/Samasaur1/DiceKit/compare/development
+[0.18.1]: https://github.com/Samasaur1/DiceKit/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/Samasaur1/Dicekit/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/Samasaur1/Dicekit/compare/v0.16.1...v0.17.0
 [0.16.1]: https://github.com/Samasaur1/DiceKit/compare/v0.16.0...v0.16.1

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -7,31 +7,30 @@ with open(".jazzy.yaml") as file:
     data = file.readlines()
 for line in data:
     if line.startswith("module_version: "):
-        version = line[len("module_version: "):]
+        version = line[len("module_version: "):-1]
 
 print("WARNING: If you continue, this script will run the standard git commands.\nOnce this script has been tested, you can remove this confirm check.\n")
 input("Input anything to continue, or use Ctrl-C to stop the script")
 
-subprocess.run("git checkout master")
-subprocess.run("git pull")
-desc = input("Input a description of this release ")
-subprocess.run(f'git tag -s v{version} -m "Version {version}: {desc}"')
-subprocess.run("git push --tags")
-subprocess.run("git checkout development")
-subprocess.run("git pull")
-subprocess.run("git rebase master")
-subprocess.run("git push")
+subprocess.run(["git", "checkout", "master"])
+subprocess.run(["git", "pull"])
+desc = input("Input a description of this release: ")
+subprocess.run(["git", "tag", "-s", f"v{version}", "-m", f"Version {version}: {desc}"])
+subprocess.run(["git", "push", "--tags"])
+subprocess.run(["git", "checkout", "development"])
+subprocess.run(["git", "pull"])
+subprocess.run(["git", "rebase", "master"])
+subprocess.run(["git", "push"])
 
-with open("CHANGELOG") as file:
-    changelog = "\n".join(list(takewhile(lambda x: not x.startswith("## "), list(takewhile(lambda x: not x.startswith("## "), list(dropwhile(lambda x: not x.startswith("## "), file.readlines()))[1:]))[1:])))
+with open("CHANGELOG.md") as file:
+    changelog = "".join(list(takewhile(lambda x: not x.startswith("## "), list(dropwhile(lambda x: not x.startswith("## "), list(dropwhile(lambda x: not x.startswith("## "), file.readlines()))[1:]))[1:])))
     # lines = file.readlines() # Reads
     # dropped = list(dropwhile(lambda x: not x.startswith("## "), lines)) # Drops up to but not including "## Upcoming"
     # droppedMore = dropped[1:] # Drops "## Upcoming"
-    # more = list(takewhile(lambda x: not x.startswith("## "), dropped)) # Drops up to but not including the latest version
+    # more = list(dropwhile(lambda x: not x.startswith("## "), droppedMore)) # Drops up to but not including the latest version
     # moore = more[1:] # Drops the latest version
-    # taken = list(takewhile(lambda x: not x.startswith("## "), droppedMore)) #Takes up to but not including the next version
-    # changelog = "\n".join(taken) #Joins the remaining lines
-
+    # taken = list(takewhile(lambda x: not x.startswith("## "), moore)) #Takes up to but not including the next version
+    # changelog = "".join(taken) #Joins the remaining lines
 
 print("WARNING: If you continue, this script will use the GitHub API to make a release.\nOnce this script has been tested, you can remove this confirm check.\n")
 input("Input anything to continue, or use Ctrl-C to stop the script")


### PR DESCRIPTION
Here's what's new:
- The release script has (hopefully) been fixed (closes #67)
- The automatic documentation has been fixed

Here's what has to happen:
1. Ensure the changelog has everything new that is being added
1. Bump version (use script)
1. Wait for CI
1. Merge
1. Run release script (equivalent to:
> 1. `git checkout master`
> 1. `git pull`
> 1. `git tag -s v$VERSION -m "Version $VERSION: $DESCRIPTION"`
> 1. `git push --tags`
> 1. `git checkout development`
> 1. `git pull`
> 1. `git rebase master`
> 1. `git push`