### PR TITLE
Update doc deployment to use new gh-pages structure

### DIFF
--- a/.deploy-docs.sh
+++ b/.deploy-docs.sh
@@ -5,13 +5,14 @@ gem install jazzy
 rm -rf docs
 rm -rf DiceKit.xcodeproj
 swift package generate-xcodeproj
-git clone --branch=gh-pages https://github.com/Samasaur1/DiceKit.git docs
+git clone --branch=gh-pages https://github.com/Samasaur1/DiceKit.git ghp
 jazzy -o newdocs -x -target,DiceKit
-rm -rf docs/*
-mv newdocs/* docs/
+mkdir ghp/docs/v$VERSION
+mv newdocs/* ghp/docs/v$VERSION
 rm -rf newdocs/
-cd docs
-echo 'section > section > p > img { margin-top: 4em; margin-right: 2em; }' >> css/jazzy.css
+cd ghp
+echo 'section > section > p > img { margin-top: 4em; margin-right: 2em; }' >> ghp/docs/v$VERSION/css/jazzy.css
+bash ../script/updateLatestDocs.sh $VERSION
 git config --global user.name "Documentation Bot"
 git config --global user.email "docbot@travis-ci.com"
 git add .

--- a/.deploy-docs.sh
+++ b/.deploy-docs.sh
@@ -7,6 +7,7 @@ rm -rf DiceKit.xcodeproj
 swift package generate-xcodeproj
 git clone --branch=gh-pages https://github.com/Samasaur1/DiceKit.git ghp
 jazzy -o newdocs -x -target,DiceKit
+VERSION=$(python3 scripts/get_version.py)
 mkdir ghp/docs/v$VERSION
 mv newdocs/* ghp/docs/v$VERSION
 rm -rf newdocs/

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.18.1
+module_version: 0.19.0
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,29 +17,29 @@ osx_image: xcode10
 
 env:
 - SWIFT_VERSION=4.2.4
-- SWIFT_VERSION=5.0.1
+- SWIFT_VERSION=5.0.3
 
 jobs:
   include:
-  - osx_image: xcode10.2
+  - osx_image: xcode11.3
     os: linux
-    env: SWIFT_VERSION=5.0.1
+    env: SWIFT_VERSION=5.1.3
     script: swift test
   - stage: test
     if: branch != master OR type = pull_request
-    osx_image: xcode10.2
+    osx_image: xcode11.3
     os: osx
-    env: SWIFT_VERSION=5.0.1
+    env: SWIFT_VERSION=5.1.3
     script: swift test
   - stage: deploy
     if: branch = master AND type = push
-    osx_image: xcode10.2
+    osx_image: xcode11.3
     os: osx
-    env: SWIFT_VERSION=5.0.1
+    env: SWIFT_VERSION=5.1.3
     script: bash .deploy-docs.sh
   - stage: danger
     os: osx
-    osx_image: xcode10.2
+    osx_image: xcode11.3
     script: swift run danger-swift ci
     install:
     - python3 scripts/include_dev_dependencies.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Upcoming]
+
+## [0.19.0] - 2019-12-26
+### Added
+- Scripts to hide/unhide dev dependencies
+
 ### Changed
 - Documentation will no longer force-push; instead it will update
+- Safety checks were removed from the release script
+
+### Fixed
+- Dev dependencies, such as Danger, are now only included, downloaded, and built on CI
 
 ## [0.18.1] - 2019-08-22
 ### Fixed
@@ -194,6 +203,7 @@ Update .travis.yml in case https://swiftenv.fuller.li/install.sh is down/has no 
 - `Rollable`: a protocol for anything that is rollable
 
 [Upcoming]: https://github.com/Samasaur1/DiceKit/compare/development
+[0.19.0]: https://github.com/Samasaur1/DiceKit/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/Samasaur1/DiceKit/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/Samasaur1/Dicekit/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/Samasaur1/Dicekit/compare/v0.16.1...v0.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Upcoming]
+### Changed
+- The structure of the GitHub Pages site has changed. There is now a `docs` directory, with subdirectories for each version. The auto-deployment of documentation has been update d to support this.
 
 ## [0.19.0] - 2019-12-26
 ### Added

--- a/scripts/get_version.py
+++ b/scripts/get_version.py
@@ -1,0 +1,9 @@
+with open(".jazzy.yaml") as file:
+    data = file.readlines()
+
+for i in range(len(data)):
+    if data[i].startswith("module_version: "):
+        version = data[i][len("module_version: "):] #I know this read call includes the \n and release.py does not, but they both work and don't add or subtract a \n. ¯\_(ツ)_/¯
+        index = i
+
+print(version, end="")

--- a/scripts/include_dev_dependencies.py
+++ b/scripts/include_dev_dependencies.py
@@ -1,4 +1,5 @@
 from os import rename as move
+from os import path
 
 with open("Package.swift") as file:
     data = file.readlines()
@@ -12,4 +13,7 @@ for i in range(len(data)):
 with open("Package.swift", "w") as file:
     file.writelines(data)
 
-move("Package.resolved.danger", "Package.swift")
+if path.exists("Package.resolved"):
+    move("Package.resolved", "Package.resolved.nodanger")
+if path.exists("Package.resolved.danger"):
+    move("Package.resolved.danger", "Package.resolved")

--- a/scripts/remove_dev_dependencies.py
+++ b/scripts/remove_dev_dependencies.py
@@ -12,4 +12,7 @@ for i in range(len(data)):
 with open("Package.swift", "w") as file:
     file.writelines(data)
 
-move("Package.resolved", "Package.resolved.danger")
+if path.exists("Package.resolved"):
+    move("Package.resolved", "Package.resolved.danger")
+if path.exists("Package.resolved.nodanger"):
+    move("Package.resolved.nodanger", "Package.resolved")

--- a/scripts/updateLatestDocs.sh
+++ b/scripts/updateLatestDocs.sh
@@ -1,0 +1,11 @@
+cat > docs/latest.html <<HERE
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Refresh" content="0; url=v$1/index.html" />
+  </head>
+  <body>
+    <p>The latest docs are available <a href="v$1/index.html">here</a>.</p>
+  </body>
+</html>
+HERE


### PR DESCRIPTION
This PR changes the way that automatic documentation deployment works, so that there is a version of the docs for each version of the library. The `gh-pages-new` branch has that new structure, and for this to be merged to `master` (or maybe even `development`), `gh-pages` needs to be changed to this new structure.

**IMPORTANT:** Remember to update `gh-pages`!