### PR TITLE
Version 0.20.0: Multiple Documentation Versions

### DIFF
--- a/.deploy-docs.sh
+++ b/.deploy-docs.sh
@@ -5,13 +5,15 @@ gem install jazzy
 rm -rf docs
 rm -rf DiceKit.xcodeproj
 swift package generate-xcodeproj
-git clone --branch=gh-pages https://github.com/Samasaur1/DiceKit.git docs
+git clone --branch=gh-pages https://github.com/Samasaur1/DiceKit.git ghp
 jazzy -o newdocs -x -target,DiceKit
-rm -rf docs/*
-mv newdocs/* docs/
+VERSION=$(python3 scripts/get_version.py)
+mkdir ghp/docs/v$VERSION
+mv newdocs/* ghp/docs/v$VERSION
 rm -rf newdocs/
-cd docs
-echo 'section > section > p > img { margin-top: 4em; margin-right: 2em; }' >> css/jazzy.css
+cd ghp
+echo 'section > section > p > img { margin-top: 4em; margin-right: 2em; }' >> ghp/docs/v$VERSION/css/jazzy.css
+bash ../script/updateLatestDocs.sh $VERSION
 git config --global user.name "Documentation Bot"
 git config --global user.email "docbot@travis-ci.com"
 git add .

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.19.0
+module_version: 0.20.0
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,29 +17,29 @@ osx_image: xcode10
 
 env:
 - SWIFT_VERSION=4.2.4
-- SWIFT_VERSION=5.0.1
+- SWIFT_VERSION=5.0.3
 
 jobs:
   include:
-  - osx_image: xcode10.2
+  - osx_image: xcode11.3
     os: linux
-    env: SWIFT_VERSION=5.0.1
+    env: SWIFT_VERSION=5.1.3
     script: swift test
   - stage: test
     if: branch != master OR type = pull_request
-    osx_image: xcode10.2
+    osx_image: xcode11.3
     os: osx
-    env: SWIFT_VERSION=5.0.1
+    env: SWIFT_VERSION=5.1.3
     script: swift test
   - stage: deploy
     if: branch = master AND type = push
-    osx_image: xcode10.2
+    osx_image: xcode11.3
     os: osx
-    env: SWIFT_VERSION=5.0.1
+    env: SWIFT_VERSION=5.1.3
     script: bash .deploy-docs.sh
   - stage: danger
     os: osx
-    osx_image: xcode10.2
+    osx_image: xcode11.3
     script: swift run danger-swift ci
     install:
     - python3 scripts/include_dev_dependencies.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scripts to hide/unhide dev dependencies
 
 ### Changed
+- The structure of the GitHub Pages site has changed. There is now a `docs` directory, with subdirectories for each version. The auto-deployment of documentation has been update d to support this.
+
+## [0.19.0] - 2019-12-26
+### Added
+- Scripts to hide/unhide dev dependencies
+
+### Changed
 - Documentation will no longer force-push; instead it will update
 - Safety checks were removed from the release script
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
-## [0.19.0] - 2019-12-26
-### Added
-- Scripts to hide/unhide dev dependencies
-
+## [0.20.0] — 2020-02-16
 ### Changed
 - The structure of the GitHub Pages site has changed. There is now a `docs` directory, with subdirectories for each version. The auto-deployment of documentation has been update d to support this.
 
@@ -210,6 +207,7 @@ Update .travis.yml in case https://swiftenv.fuller.li/install.sh is down/has no 
 - `Rollable`: a protocol for anything that is rollable
 
 [Upcoming]: https://github.com/Samasaur1/DiceKit/compare/development
+[0.20.0]: https://github.com/Samasaur1/DiceKit/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/Samasaur1/DiceKit/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/Samasaur1/DiceKit/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/Samasaur1/Dicekit/compare/v0.17.0...v0.18.0

--- a/scripts/get_version.py
+++ b/scripts/get_version.py
@@ -1,0 +1,9 @@
+with open(".jazzy.yaml") as file:
+    data = file.readlines()
+
+for i in range(len(data)):
+    if data[i].startswith("module_version: "):
+        version = data[i][len("module_version: "):] #I know this read call includes the \n and release.py does not, but they both work and don't add or subtract a \n. ¯\_(ツ)_/¯
+        index = i
+
+print(version, end="")

--- a/scripts/updateLatestDocs.sh
+++ b/scripts/updateLatestDocs.sh
@@ -1,0 +1,11 @@
+cat > docs/latest.html <<HERE
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Refresh" content="0; url=v$1/index.html" />
+  </head>
+  <body>
+    <p>The latest docs are available <a href="v$1/index.html">here</a>.</p>
+  </body>
+</html>
+HERE


### PR DESCRIPTION
Here's what's new:
- There are now multiple versions of the documentation hosted on the GitHub Pages site (#72)
- The GitHub Pages site can now be easily changed to have a page describing the project, in addition to hosting docs (#72)
- The auto-documentation deployment uses the new structure (#71)

Here's what has to happen:
- [x] Merge #72.
- [x] Ensure the changelog has everything new that is being added
- [x] Bump version (run `updateVersion.sh`)
1. Wait for CI
1. Merge
1. Run `release.sh`