### PR TITLE
Version 0.20.2: Don't crash for dice probabilities with no dice (fixes #75)

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.20.1
+module_version: 0.20.2
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
+## [0.20.2] — 2020-07-01
+### Fixed
+- Dice objects with no dice in them (i.e., modifiers only or empty objects) no longer crash when accessing their probabilities property (closes #75)
+
 ## [0.20.1] — 2020-06-30
 ### Added
 - `DKError`/`Error`'s `localizedDescription` field now has a useful value (based off of the documentation for those fields).
@@ -218,6 +222,7 @@ Update .travis.yml in case https://swiftenv.fuller.li/install.sh is down/has no 
 - `Rollable`: a protocol for anything that is rollable
 
 [Upcoming]: https://github.com/Samasaur1/DiceKit/compare/development
+[0.20.2]: https://github.com/Samasaur1/DiceKit/compare/v0.20.1...v0.20.2
 [0.20.1]: https://github.com/Samasaur1/DiceKit/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/Samasaur1/DiceKit/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/Samasaur1/DiceKit/compare/v0.18.1...v0.19.0

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -352,6 +352,7 @@ extension Dice: Rollable {
     private func calculateChances() -> Chances {
         //Gets an array of all the dice (which can include multiple of the same die) to loop through.
         var sortedDice: [Die] = []
+        if dice.isEmpty { return Chances(chances: [modifier: .one])}
         for (die, count) in dice {
             for _ in 0..<count {
                 sortedDice.append(die)

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -352,7 +352,7 @@ extension Dice: Rollable {
     private func calculateChances() -> Chances {
         //Gets an array of all the dice (which can include multiple of the same die) to loop through.
         var sortedDice: [Die] = []
-        if dice.isEmpty { return Chances(chances: [modifier: .one])}
+        if dice.isEmpty { return Chances(chances: [modifier: .one]) }
         for (die, count) in dice {
             for _ in 0..<count {
                 sortedDice.append(die)

--- a/Tests/DiceKitTests/DiceTests.swift
+++ b/Tests/DiceKitTests/DiceTests.swift
@@ -368,4 +368,18 @@ final class DiceTests: XCTestCase {
         XCTAssertEqual(dice6d12, Dice((Die.d12, 6)))
         XCTAssertEqual(dice980d1, Dice(try! Die(sides: 1), count: 980))
     }
+
+    func testProbabilities() {
+        let empty = Dice(dice: [])
+        let five = Dice(dice: [], withModifier: 5)
+        let d4 = Dice(.d4)
+        let d6plus1 = Dice(.d6, withModifier: 1)
+
+        XCTAssertEqual(empty.probabilities, Chances(chances: [0: .one]))
+        XCTAssertEqual(five.probabilities, Chances(chances: [5: .one]))
+        let c = try! Chance.oneOut(of: 4)
+        XCTAssertEqual(d4.probabilities, Chances(chances: [1: c, 2: c, 3: c, 4: c]))
+        let c2 = try! Chance.oneOut(of: 6)
+        XCTAssertEqual(d6plus1.probabilities, Chances(chances: [2: c2, 3: c2, 4: c2, 5: c2, 6: c2, 7: c2]))
+    }
 }

--- a/Tests/DiceKitTests/XCTestManifests.swift
+++ b/Tests/DiceKitTests/XCTestManifests.swift
@@ -87,6 +87,7 @@ extension DiceTests {
         ("testMultipleRepeatedDieStringParsing", testMultipleRepeatedDieStringParsing),
         ("testMultipleSeparateDieStringParsing", testMultipleSeparateDieStringParsing),
         ("testNegativeMultipleDieStringParsing", testNegativeMultipleDieStringParsing),
+        ("testProbabilities", testProbabilities),
         ("testRolling", testRolling),
         ("testRollingMultipleTimes", testRollingMultipleTimes),
         ("testSingleDieAndSingleModifierStringParsing", testSingleDieAndSingleModifierStringParsing),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -6,3 +6,4 @@ var tests = [XCTestCaseEntry]()
 tests += DiceKitTests.__allTests()
 
 XCTMain(tests)
+


### PR DESCRIPTION
Here's what's new:
- `Dice` objects with no dice in them (i.e., modifiers only or empty objects) no longer crash when accessing their `probabilities` property (closes #75)

Here's what has to happen:
- [x] Ensure the changelog has everything new that is being added
- [x] Bump version (run `updateVersion.sh`)
1. Wait for CI
1. Merge
1. Run `release.sh`