### PR TITLE
Version 0.22.0: Caching probabilities calculation across objects

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.21.0
+module_version: 0.22.0
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:
@@ -26,3 +26,5 @@ custom_categories:
    children:
    - Chances
    - Chance
+   - Caching
+   - ENABLE_CACHING

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Upcoming]
+### Added
+- More documentation on the `chances` property introduced in v0.21.0
 
 ## [0.21.0] — 2020-07-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Upcoming]
+
+## [0.22.0] — 2020-07-02
 ### Added
 - More documentation on the `chances` property introduced in v0.21.0
+- `Dice` caches the result of its computations for `probabilities` between objects (closes [#78](https://github.com/Samasaur1/DiceKit/issues/78)). See the issue (linked) or the pull request [here](https://github.com/Samasaur1/DiceKit/pull/79) for more information on caching.
+- `Dice` now conforms to `Hashable` (adding for caching, but handy in general)
 
 ## [0.21.0] — 2020-07-01
 ### Added
@@ -243,6 +247,7 @@ Update .travis.yml in case https://swiftenv.fuller.li/install.sh is down/has no 
 - `Rollable`: a protocol for anything that is rollable
 
 [Upcoming]: https://github.com/Samasaur1/DiceKit/compare/development
+[0.22.0]: https://github.com/Samasaur1/DiceKit/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/Samasaur1/DiceKit/compare/v0.20.2...v0.21.0
 [0.20.2]: https://github.com/Samasaur1/DiceKit/compare/v0.20.1...v0.20.2
 [0.20.1]: https://github.com/Samasaur1/DiceKit/compare/v0.20.0...v0.20.1

--- a/Sources/DiceKit/Caching.swift
+++ b/Sources/DiceKit/Caching.swift
@@ -17,7 +17,6 @@ public protocol Caching {
     static var enableCaching: Bool { get set }
 }
 
-
 /// Whether or not DiceKit types should cache the results of probability computations across objects.
 /// 
 /// The results of rolling are **NOT** cached.

--- a/Sources/DiceKit/Caching.swift
+++ b/Sources/DiceKit/Caching.swift
@@ -1,0 +1,41 @@
+/// An object that caches the results of intensive computations.
+///
+/// In DiceKit, the only cached values are probability computations,
+///   which can be very intensive.
+///
+/// The results of rolling are **NOT** cached.
+///
+/// **Implemented By**
+/// * `Dice`
+///
+/// See `ENABLE_CACHING` for configuring caching of all `Caching` types.
+///
+/// - Since: 0.22.0
+/// - Author: Samasaur
+public protocol Caching {
+    /// Whether or not caching is enabled.
+    static var enableCaching: Bool { get set }
+}
+
+
+/// Whether or not DiceKit types should cache the results of probability computations across objects.
+/// 
+/// The results of rolling are **NOT** cached.
+///
+/// Every type that supports caching has its own `enableCaching` property.
+/// Setting this property overwrites each type's configuration.
+/// This property returns `true` when *every* supported type has caching enabled,
+///   and `false` when *any* supported type has caching disabled.
+///
+/// **Types that currently support caching:**
+/// * `Dice`
+///
+/// - Since: 0.22.0
+public var ENABLE_CACHING: Bool {
+    get {
+        return Dice.enableCaching
+    }
+    set {
+        Dice.enableCaching = newValue
+    }
+}

--- a/Sources/DiceKit/Chances.swift
+++ b/Sources/DiceKit/Chances.swift
@@ -29,6 +29,20 @@ public struct Chances {
         }
     }
     /// The rolls and the chances of them occurring.
+    ///
+    /// This is the property one should use in order to iterate through the possibilities, like so:
+    ///
+    /// ```
+    /// let chances: Chances = getChancesFromSomewhereElse()
+    /// let arr = chances.chances.sorted(by: { first, second in
+    ///     first.key < second.key
+    /// })
+    /// for (roll, chance) in arr {
+    ///     print("The chance of rolling a \(roll) is \(chance.n) out of \(chance.d)")
+    /// }
+    /// ```
+    ///
+    /// - Since: 0.21.0
     public private(set) var chances: [Roll: Chance]
     /// The chance of the given roll occurring.
     ///

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -3,7 +3,7 @@
 /// The properties of `Dice` objects are immutable; use the addition operators to combine them with other `Die` objects or modifiers. You can use compound assignment operators if you want, so long as you declare the `Dice` object as a `var` instead of a `let` constant.
 ///
 /// - Author: Samasaur
-public struct Dice {
+public struct Dice: Caching {
     /// The dice that make up this collection, along with how many times they appear.
     ///
     /// This `[Die: Int]` dictionary stores the types of dice that appear, paired with the number of times they appear. For example:
@@ -267,7 +267,7 @@ public struct Dice {
     /// The probabilities of all possible rolls.
     ///
     ///  Since 0.22.0, caches previous computations, even if they were on different objects.
-    ///  See `__cache`
+    ///  See `enableCaching`, `ENABLE_CACHING` for caching configuration
     ///
     /// - Since: 0.17.0
     public var probabilities: Chances {
@@ -281,7 +281,12 @@ public struct Dice {
 
     fileprivate static var __cache: [Dice: Chances]? = [:]
 
-    /// Whether or not `Dice` should cache the results of computations across objects.
+    /// Whether or not `Dice` should cache the results of probability computations across objects.
+    ///
+    /// **Note:** The results of rolling are **NOT** cached.
+    ///
+    /// Setting this value to `false` and then to `true` will clear the cache.
+    /// See `ENABLE_CACHING` for configuration of caching for all types at once.
     ///
     /// - Since: 0.22.0
     public static var enableCaching = true {
@@ -294,21 +299,6 @@ public struct Dice {
                 }
             }
         }
-    }
-}
-
-/// Whether or not DiceKit types should cache the results of computations across objects.
-///
-/// **Types that currently support caching:**
-/// * `Dice`
-///
-/// - Since: 0.22.0
-public var enableCaching: Bool {
-    get {
-        return Dice.enableCaching
-    }
-    set {
-        Dice.enableCaching = newValue
     }
 }
 

--- a/Sources/DiceKit/Dice.swift
+++ b/Sources/DiceKit/Dice.swift
@@ -266,9 +266,49 @@ public struct Dice {
 
     /// The probabilities of all possible rolls.
     ///
+    ///  Since 0.22.0, caches previous computations, even if they were on different objects.
+    ///  See `__cache`
+    ///
     /// - Since: 0.17.0
     public var probabilities: Chances {
-        return __probabilities.value(input: self)
+        if let val = Dice.__cache?[self] {
+            return val
+        }
+        let val = __probabilities.value(input: self)
+        Dice.__cache?[self] = val
+        return val
+    }
+
+    fileprivate static var __cache: [Dice: Chances]? = [:]
+
+    /// Whether or not `Dice` should cache the results of computations across objects.
+    ///
+    /// - Since: 0.22.0
+    public static var enableCaching = true {
+        didSet {
+            if enableCaching == false {
+                __cache = nil
+            } else {
+                if __cache == nil {
+                    __cache = [:]
+                }
+            }
+        }
+    }
+}
+
+/// Whether or not DiceKit types should cache the results of computations across objects.
+///
+/// **Types that currently support caching:**
+/// * `Dice`
+///
+/// - Since: 0.22.0
+public var enableCaching: Bool {
+    get {
+        return Dice.enableCaching
+    }
+    set {
+        Dice.enableCaching = newValue
     }
 }
 
@@ -418,6 +458,13 @@ extension Dice: Equatable {
             return false
         }
         return true
+    }
+}
+
+extension Dice: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.dice)
+        hasher.combine(self.modifier)
     }
 }
 

--- a/Sources/DiceKit/Typealiases.swift
+++ b/Sources/DiceKit/Typealiases.swift
@@ -20,3 +20,7 @@ public typealias DKWeightedDie = WeightedDie
 public typealias DKChance = Chance
 /// See `Chances`.
 public typealias DKChances = Chances
+/// See `Caching`.
+///
+/// - Since: 0.22.0
+public typealias DKCaching = Caching

--- a/Tests/DiceKitTests/ChancesTests.swift
+++ b/Tests/DiceKitTests/ChancesTests.swift
@@ -38,4 +38,9 @@ final class ChancesTests: XCTestCase {
 
         XCTAssertAllEqual(c, c2, c3)
     }
+
+    func testSubscriptAndDictionaryProperty() {
+        let c = Chances(chances: [5: 0.234, 8: 0.432])
+        XCTAssertEqual(c.chances[5], c[of: 5])
+    }
 }

--- a/Tests/DiceKitTests/XCTestManifests.swift
+++ b/Tests/DiceKitTests/XCTestManifests.swift
@@ -25,6 +25,7 @@ extension ChancesTests {
         ("testHashable", testHashable),
         ("testInitialization", testInitialization),
         ("testSubscript", testSubscript),
+        ("testSubscriptAndDictionaryProperty", testSubscriptAndDictionaryProperty),
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -6,4 +6,3 @@ var tests = [XCTestCaseEntry]()
 tests += DiceKitTests.__allTests()
 
 XCTMain(tests)
-


### PR DESCRIPTION
# Here's what's new:
- Dice caches the result of its computations for `probabilities` between objects (closes #78).
- More documentation for the `Chances.chances` property introduced in [v0.21.0](https://github.com/Samasaur1/DiceKit/releases/tag/v0.21.0)

## More detail on caching:
### Use case
Here's an excerpt from that issue:
```swift
let first = Dice(.d4, count: 10)
first.probabilities

let second = first
second.probabilities

let third = Dice(.d4, count: 10) // functionally identical
third.probabilities
```
In the current version, `second` does not need to repeat its calculations, but `third` does. Caching means that `third` will not need to repeat the calculations. Neither would any other `Dice` object that represents 10d4.
### Disabling caching
Caching is on by default, but it can easily be disabled. There are two ways to disable it, in order to be future-proof:
```swift
Dice.enableCaching //true
DiceKit.enableCaching //true

Dice.enableCaching = false

Dice.enableCaching //false
DiceKit.enableCaching //false

DiceKit.enableCaching = true

Dice.enableCaching //true
DiceKit.enableCaching //true
```
Basically, `Dice.enableCaching` enables/disables the cache for `Dice` only, while `DiceKit.enableCaching` *sets* caching for every type that supports it (currently only `Dice`) and *gets* whether all caching types have caching enabled. For example:
```swift
Dice.enableCaching = true
SomeFutureCachingType.enableCaching = false

DiceKit.enableCaching //false

DiceKit.enableCaching = true

Dice.enableCaching //true
SomeFutureCachingType.enableCaching //true

DiceKit.enableCaching = false

Dice.enableCaching //false
SomeFutureCachingType.enableCaching //false
```

# Here's what has to happen:
- [x] Update the documentation on all the `enableCaching` members (I renamed it a bunch while writing, and I don't think it is correct)
- [x] Add a `Caching`/`Cachable` protocol that `Dice` conforms to
- [x] Ensure the changelog has everything new that is being added
- [x] Bump version (run `updateVersion.sh`)
1. Wait for CI
1. Merge
1. Run `release.sh`
