### PR TITLE
Version 0.23.0: Explicitly support versions and platforms

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,12 +6,13 @@ name: PR
 # events but only for the master branch
 on:
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   test:
-    name: Test Swift ${{ matrix.swift }} on ${{ matrix.os }}
+    name: Test Swift ${{ matrix.swift }}.x on ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-16.04, ubuntu-latest]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,6 +20,8 @@ jobs:
         exclude:
           - os: macos-latest
             swift: "5.2"
+          - os: macos-latest
+            swift: "4.2"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,23 +15,17 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-16.04, ubuntu-latest]
-#        swift: ["4.2", "5.0", "5.1", "5.2"]
-        swift: ["4.2.4", "5.0.3", "5.1.5", "5.2.4"]
+        swift: ["4.2", "5.0", "5.1", "5.2"]
         exclude:
           - os: macos-latest
-            swift: "5.2.4"
+            swift: "5.2"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-#      - uses: fwal/setup-swift@v1
-#        with:
-#          swift-version: ${{ matrix.swift }}
-      - name: Install Swift
-        run: |
-          eval "$(curl -sL https://swiftenv.fuller.li/install.sh || curl -sL https://raw.githubusercontent.com/kylef/swiftenv/master/docs/install.sh)"
-          swift --version
-        env:
-          SWIFT_VERSION: ${{ matrix.swift }}
+      - uses: fwal/setup-swift@v1
+        with:
+          swift-version: ${{ matrix.swift }}
+      - run: swift --version
       - run: swift test
   danger:
     name: Danger
@@ -39,15 +33,10 @@ jobs:
     needs: [test]
     steps:
     - uses: actions/checkout@v2
-#    - uses: fwal/setup-swift@v1
-#      with:
-#        swift-version: 5.2.4
-    - name: Install Swift
-      run: |
-        eval "$(curl -sL https://swiftenv.fuller.li/install.sh || curl -sL https://raw.githubusercontent.com/kylef/swiftenv/master/docs/install.sh)"
-        swift --version
-      env:
-        SWIFT_VERSION: ${{ matrix.swift }}
+    - uses: fwal/setup-swift@v1
+      with:
+        swift-version: "5"
+    - run: swift --version
     - name: Install Danger
       run: |
         python3 scripts/include_dev_dependencies.py

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -1,12 +1,10 @@
-# This is a basic workflow to help you get started with Actions
+name: Push (master)
 
-name: Push
+on:
+  push:
+    branches:
+      - master
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
-on: push
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   test:
     name: Test Swift ${{ matrix.swift }}.x on ${{ matrix.os }}
@@ -17,7 +15,6 @@ jobs:
         exclude:
           - os: macos-latest
             swift: "5.2"
-            if: github.ref == 'master'
           - os: macos-latest
             swift: "4.2"
     runs-on: ${{ matrix.os }}
@@ -30,7 +27,6 @@ jobs:
       - run: swift test
   deploy:
     name: Deploy
-    if: github.ref == 'master'
     runs-on: macos-latest
     needs: [test]
     steps:

--- a/.github/workflows/push-nonmaster.yml
+++ b/.github/workflows/push-nonmaster.yml
@@ -1,0 +1,25 @@
+name: Push (non-master)
+
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  test:
+    name: Test Swift ${{ matrix.swift }}.x on ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-16.04, ubuntu-latest]
+        swift: ["4.2", "5.0", "5.1", "5.2"]
+        exclude:
+          - os: macos-latest
+            swift: "4.2"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: fwal/setup-swift@v1
+        with:
+          swift-version: ${{ matrix.swift }}
+      - run: swift --version
+      - run: swift test

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ on: push
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   test:
-    name: Test Swift ${{ matrix.swift }} on ${{ matrix.os }}
+    name: Test Swift ${{ matrix.swift }}.x on ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest, ubuntu-16.04, ubuntu-latest]
@@ -17,6 +17,7 @@ jobs:
         exclude:
           - os: macos-latest
             swift: "5.2"
+            if: github.red == 'master'
           - os: macos-latest
             swift: "4.2"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,23 +13,17 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-16.04, ubuntu-latest]
-#        swift: ["4.2", "5.0", "5.1", "5.2"]
-        swift: ["4.2.4", "5.0.3", "5.1.5", "5.2.4"]
+        swift: ["4.2", "5.0", "5.1", "5.2"]
         exclude:
           - os: macos-latest
-            swift: "5.2.4"
+            swift: "5.2"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-#      - uses: fwal/setup-swift@v1
-#        with:
-#          swift-version: ${{ matrix.swift }}
-      - name: Install Swift
-        run: |
-          eval "$(curl -sL https://swiftenv.fuller.li/install.sh || curl -sL https://raw.githubusercontent.com/kylef/swiftenv/master/docs/install.sh)"
-          swift --version
-        env:
-          SWIFT_VERSION: ${{ matrix.swift }}
+      - uses: fwal/setup-swift@v1
+        with:
+          swift-version: ${{ matrix.swift }}
+      - run: swift --version
       - run: swift test
   deploy:
     name: Deploy
@@ -38,15 +32,10 @@ jobs:
     needs: [test]
     steps:
     - uses: actions/checkout@v2
-#    - uses: fwal/setup-swift@v1
-#      with:
-#        swift-version: 5.2.4
-    - name: Install Swift
-      run: |
-        eval "$(curl -sL https://swiftenv.fuller.li/install.sh || curl -sL https://raw.githubusercontent.com/kylef/swiftenv/master/docs/install.sh)"
-        swift --version
-      env:
-        SWIFT_VERSION: ${{ matrix.swift }}
+    - uses: fwal/setup-swift@v1
+      with:
+        swift-version: "5"
+    - run: swift --version
     - name: Install Danger
       run: |
         python3 scripts/include_dev_dependencies.py

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
         exclude:
           - os: macos-latest
             swift: "5.2"
-            if: github.red == 'master'
+            if: github.ref == 'master'
           - os: macos-latest
             swift: "4.2"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,8 @@ jobs:
         exclude:
           - os: macos-latest
             swift: "5.2"
+          - os: macos-latest
+            swift: "4.2"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.22.0
+module_version: 0.23.0
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
-## [0.23.0] — 2020-07-09
+## [0.23.0] - 2020-07-09
 ### Added
 - A `Package@swift-5.0.swift` file in order to be able to specify supported platforms
 - Supported versions of Swift are listed in the package manifest file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
+## [0.23.0] — 2020-07-09
+### Added
+- A `Package@swift-5.0.swift` file in order to be able to specify supported platforms
+- Supported versions of Swift are listed in the package manifest file
+
+### Changed
+- Migrate from `Array.index(of:)` to `Array.firstIndex(of:)`
+- Continue to define our own implementation of `count(where:)` until at least Swift 6, because (as I found out) the implementation in the standard library was removed because of its impact on type-checker performance.
+- Makes the GitHub Actions workflow output nicer.
+
+### Fixed
+- Uses the correct Swift version in GitHub Actions tests (closes [#80](https://github.com/Samasaur1/DiceKit/issues/80))
+
 ## [0.22.0] — 2020-07-02
 ### Added
 - More documentation on the `chances` property introduced in v0.21.0
@@ -247,6 +260,7 @@ Update .travis.yml in case https://swiftenv.fuller.li/install.sh is down/has no 
 - `Rollable`: a protocol for anything that is rollable
 
 [Upcoming]: https://github.com/Samasaur1/DiceKit/compare/development
+[0.23.0]: https://github.com/Samasaur1/DiceKit/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/Samasaur1/DiceKit/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/Samasaur1/DiceKit/compare/v0.20.2...v0.21.0
 [0.20.2]: https://github.com/Samasaur1/DiceKit/compare/v0.20.1...v0.20.2

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -1,10 +1,13 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 // Managed by ice
 
 import PackageDescription
 
 let package = Package(
     name: "DiceKit",
+    platforms: [
+        .iOS(.v8), .macOS(.v10_10), .watchOS(.v2), .tvOS(.v9)// .linux (not a SupportedPlatform, just a Platform
+    ],
     products: [
         .library(name: "DiceKit", targets: ["DiceKit"]),
     ],
@@ -16,5 +19,5 @@ let package = Package(
         .testTarget(name: "DiceKitTests", dependencies: ["DiceKit"]), //nodev
 //      .testTarget(name: "DiceKitTests", dependencies: ["DiceKit", "Danger"]), //dev
     ],
-    swiftLanguageVersions: [.v4_2, .version("5")]
+    swiftLanguageVersions: [.v4_2, .v5]
 )

--- a/Sources/DiceKit/Rollable.swift
+++ b/Sources/DiceKit/Rollable.swift
@@ -128,27 +128,27 @@ public extension Rollable {
             return (rolls.min() ?? 0) + (rolls.max() ?? 0)
         case .dropHighest:
             guard rolls.count > 1 else { return 0 }
-            rolls.remove(at: rolls.index(of: rolls.max()!)!)
+            rolls.remove(at: rolls.firstIndex(of: rolls.max()!)!)
             return rolls.sum
         case .dropLowest:
             guard rolls.count > 1 else { return 0 }
-            rolls.remove(at: rolls.index(of: rolls.min()!)!)
+            rolls.remove(at: rolls.firstIndex(of: rolls.min()!)!)
             return rolls.sum
         case .dropOutsides:
             guard rolls.count > 2 else { return 0 }
-            rolls.remove(at: rolls.index(of: rolls.max()!)!)
-            rolls.remove(at: rolls.index(of: rolls.min()!)!)
+            rolls.remove(at: rolls.firstIndex(of: rolls.max()!)!)
+            rolls.remove(at: rolls.firstIndex(of: rolls.min()!)!)
             return rolls.sum
         case .dropLow(let amountToDrop):
             guard rolls.count >= amountToDrop else { return 0 }
             for _ in 0..<amountToDrop {
-                rolls.remove(at: rolls.index(of: rolls.min()!)!)
+                rolls.remove(at: rolls.firstIndex(of: rolls.min()!)!)
             }
             return rolls.sum
         case .dropHigh(let amountToDrop):
             guard rolls.count >= amountToDrop else { return 0 }
             for _ in 0..<amountToDrop {
-                rolls.remove(at: rolls.index(of: rolls.max()!)!)
+                rolls.remove(at: rolls.firstIndex(of: rolls.max()!)!)
             }
             return rolls.sum
         }

--- a/Sources/DiceKit/Utilities.swift
+++ b/Sources/DiceKit/Utilities.swift
@@ -25,7 +25,7 @@ internal extension Array where Element == Double {
         return total
     }
 }
-#if !swift(>=5.1) //Can't use `#if swift(<5.1)` for earlier than Swift 5
+#if !swift(>=6) //Can't use `#if swift(<5.1)` for earlier than Swift 5
 internal extension Sequence {
     func count(where predicate: (Element) throws -> Bool) rethrows -> Int {
         var count = 0
@@ -38,7 +38,8 @@ internal extension Sequence {
     }
 }
 #else
-#error("Do we still need this?")
+#error("Has count(where:) finally been re-added?")
+//For context, `count(where:)` was briefly in the standard library, but was removed for type-checking performance reasons.
 #endif
 
 import Foundation

--- a/scripts/include_dev_dependencies.py
+++ b/scripts/include_dev_dependencies.py
@@ -13,6 +13,18 @@ for i in range(len(data)):
 with open("Package.swift", "w") as file:
     file.writelines(data)
 
+with open("Package@swift-5.0.swift") as file:
+    data = file.readlines()
+
+for i in range(len(data)):
+    if "//dev" in data[i]:
+        data[i] = data[i][2:]
+    if "//nodev" in data[i]:
+        data[i] = "//" + data[i]
+
+with open("Package@swift-5.0.swift", "w") as file:
+    file.writelines(data)
+
 if path.exists("Package.resolved"):
     move("Package.resolved", "Package.resolved.nodanger")
 if path.exists("Package.resolved.danger"):

--- a/scripts/remove_dev_dependencies.py
+++ b/scripts/remove_dev_dependencies.py
@@ -13,6 +13,18 @@ for i in range(len(data)):
 with open("Package.swift", "w") as file:
     file.writelines(data)
 
+with open("Package@swift-5.0.swift") as file:
+    data = file.readlines()
+
+for i in range(len(data)):
+    if "//dev" in data[i]:
+        data[i] = "//" + data[i]
+    if "//nodev" in data[i]:
+        data[i] = data[i][2:]
+
+with open("Package@swift-5.0.swift", "w") as file:
+    file.writelines(data)
+
 if path.exists("Package.resolved"):
     move("Package.resolved", "Package.resolved.danger")
 if path.exists("Package.resolved.nodanger"):


### PR DESCRIPTION
Here's what's new:
- Lists supported Swift versions in the `Package.swift` file
- A `Package@swift-5.0.swift` file in order to be able to specify supported platforms
  - Updates the dev dependency scripts to modify both `Package` files
- Migrates from `Array.index(of:)` to `Array.firstIndex(of:)`
- Continue to define our own implementation of `count(where:)` until at least Swift 6, because (as I found out) the implementation in the standard library was removed because of its impact on type-checker performance.

**Edit:** more was added, see [here](https://github.com/Samasaur1/DiceKit/pull/81#issuecomment-656294031) (comment below) (closes #80)

Here's what has to happen:
- [x] Ensure the changelog has everything new that is being added
- [x] Bump version (run `updateVersion.sh`)
1. Wait for CI
1. Merge
1. Run `release.sh`
