### PR TITLE
Version 0.24.1: Update Dangerfile to report tasks in correct order

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-16.04, ubuntu-latest]
-        swift: ["4.2", "5.0", "5.1", "5.2"]
+        swift: ["4.2", "5.0", "5.1", "5.2", "5.3"]
         exclude:
           - os: macos-latest
             swift: "5.2"
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: fwal/setup-swift@v1
       with:
-        swift-version: "5"
+        swift-version: "5.2"
     - run: swift --version
     - name: Install Danger
       run: |

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.24.0
+module_version: 0.24.1
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
-## [0.24.1] - 2020-10-12
+## [0.24.1] - 2020-10-15
 ### Fixed
 - Danger now reports tasks in the correct order
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
-## [0.24.1] - 2020-10-03
+## [0.24.1] - 2020-10-04
 ### Fixed
 - Danger now reports tasks in the correct order
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
-## [0.24.1] - 2020-10-09
+## [0.24.1] - 2020-10-12
 ### Fixed
 - Danger now reports tasks in the correct order
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
-## [0.24.1] - 2020-10-08
+## [0.24.1] - 2020-10-09
 ### Fixed
 - Danger now reports tasks in the correct order
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
-## [0.24.1] - 2020-10-04
+## [0.24.1] - 2020-10-08
 ### Fixed
 - Danger now reports tasks in the correct order
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
+## [0.24.1] - 2020-10-03
+### Fixed
+- Danger now reports tasks in the correct order
+
 ## [0.24.0] - 2020-07-13
 ### Added
 - `Chance` objects can now be multiplied together (which, mathematically, represents the chance of both occurring)
@@ -273,6 +277,7 @@ Update .travis.yml in case https://swiftenv.fuller.li/install.sh is down/has no 
 - `Rollable`: a protocol for anything that is rollable
 
 [Upcoming]: https://github.com/Samasaur1/DiceKit/compare/development
+[0.24.1]: https://github.com/Samasaur1/DiceKit/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/Samasaur1/DiceKit/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/Samasaur1/DiceKit/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/Samasaur1/DiceKit/compare/v0.21.0...v0.22.0

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -113,10 +113,10 @@ if let body = danger.github.pullRequest.body {
         let count = allTaskLines.count
         for (num, line) in allTaskLines.enumerated().reversed() {
             if line.range(of: #"^- \[x\] "#, options: .regularExpression) != nil {
-                message("**Task \(count - num) completed:** \(line.dropFirst(6))")
+                message("**Task \(num + 1) completed:** \(line.dropFirst(6))")
                 continue
             }
-            fail("**Task \(count - num) incomplete:** \(line.dropFirst(6))")  // "- [ ] "
+            fail("**Task \(num + 1) incomplete:** \(line.dropFirst(6))")  // "- [ ] "
         }
     } else {
         warn("PR body doesn't appear to have any tasks, which it should")

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -110,7 +110,6 @@ if let body = danger.github.pullRequest.body {
         let split = body.split { $0.isNewline }
         let allTaskLines = split
             .filter { $0.range(of: #"^- \[[x ]\] "#, options: .regularExpression) != nil }
-        let count = allTaskLines.count
         for (num, line) in allTaskLines.enumerated().reversed() {
             if line.range(of: #"^- \[x\] "#, options: .regularExpression) != nil {
                 message("**Task \(num + 1) completed:** \(line.dropFirst(6))")

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -110,12 +110,13 @@ if let body = danger.github.pullRequest.body {
         let split = body.split { $0.isNewline }
         let allTaskLines = split
             .filter { $0.range(of: #"^- \[[x ]\] "#, options: .regularExpression) != nil }
-        for (num, line) in allTaskLines.enumerated() {
+        let count = allTaskLines.count
+        for (num, line) in allTaskLines.enumerated().reversed() {
             if line.range(of: #"^- \[x\] "#, options: .regularExpression) != nil {
-                message("**Task \(num + 1) completed:** \(line.dropFirst(6))")
+                message("**Task \(count - num) completed:** \(line.dropFirst(6))")
                 continue
             }
-            fail("**Task \(num + 1) incomplete:** \(line.dropFirst(6))")  // "- [ ] "
+            fail("**Task \(count - num) incomplete:** \(line.dropFirst(6))")  // "- [ ] "
         }
     } else {
         warn("PR body doesn't appear to have any tasks, which it should")


### PR DESCRIPTION
Here's what's new:
- Danger should report tasks in the correct order in PRs now (closes #82)

Here's what has to happen:
- [x] Ensure the changelog has everything new that is being added
- [x] Bump version (run `updateVersion.sh`)
1. Wait for CI
1. Merge
1. Run `release.sh`