### PR TITLE
Allow iterating through Chances

### DIFF
--- a/Sources/DiceKit/Chances.swift
+++ b/Sources/DiceKit/Chances.swift
@@ -99,3 +99,8 @@ fileprivate extension Dictionary.Values where Dictionary.Value == Chance {
         return total
     }
 }
+extension Chances: Sequence {
+    public func makeIterator() -> IndexingIterator<[Dictionary<Roll, Chance>.Element]> {
+        return chances.sorted { $0.key < $1.key }.makeIterator()
+    }
+}

--- a/Tests/DiceKitTests/ChancesTests.swift
+++ b/Tests/DiceKitTests/ChancesTests.swift
@@ -43,4 +43,11 @@ final class ChancesTests: XCTestCase {
         let c = Chances(chances: [5: 0.234, 8: 0.432])
         XCTAssertEqual(c.chances[5], c[of: 5])
     }
+
+    func testSequence() {
+        let chances = Chances(chances: [5: 0.234, 8: 0.432])
+        for (r, c) in chances {
+            print("The chance of rolling \(r) is \(c)")
+        }
+    }
 }


### PR DESCRIPTION
This PR allows iterating through `Chances` objects. It somewhat addresses #94, but not completely. It _might_ be worth merging anyway, since I can only choose one of the two ways to iterate through `Dice`, and I'm not sure which one to pick.