### PR TITLE
Version 0.25.1: Fix deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: deploy
 
 on:
   push:
@@ -22,7 +22,7 @@ jobs:
         ref: gh-pages
         path: ghp
     - name: Determine VERSION
-      run: echo 'VERSION=${GITHUB_REF:#refs/tags/v}' >> $GITHUB_ENV #lops of that part from the beginning of the string, could be ${GITHUB_REF:11} to chop off 11 characters
+      run: 'echo "VERSION=${GITHUB_REF:#refs/tags/v}" >> $GITHUB_ENV' #lops of that part from the beginning of the string, could be ${GITHUB_REF:11} to chop off 11 characters
     - name: Process docs
       run: |
         mkdir ghp/docs/v$VERSION
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Determine VERSION
-      run: echo 'VERSION=${GITHUB_REF:#refs/tags/v}' >> $GITHUB_ENV #lops of that part from the beginning of the string, could be ${GITHUB_REF:11} to chop off 11 characters
+      run: 'echo "VERSION=${GITHUB_REF:#refs/tags/v}" >> $GITHUB_ENV' #lops of that part from the beginning of the string, could be ${GITHUB_REF:11} to chop off 11 characters
     - name: Determine release name
       run: |
         NAME=$(git tag -l --format='%(contents)' v$VERSION | head -n 1)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,12 @@ jobs:
         echo "Determined release name as '$NAME'" >> $GITHUB_STEP_SUMMARY
     - name: Determine release body (from CHANGELOG)
       run: cat CHANGELOG.md | sed '1,/^## /d' | sed '1,/^## /d' | sed '/^## /,$d' | tee body.md
+    - name: Add links to release body
+      run: |
+        CH_VERSION=$(echo $VERSION | tr -d .)
+        CH_DATE=$(grep "## .$VERSION." CHANGELOG.md | tail -c 11 | head -n 10)
+        echo "[See changelog](https://github.com/Samasaur1/DiceKit/blob/master/CHANGELOG.md#$CH_VERSION--$CH_DATE)" | tee -a body.md
+        echo "[See docs](https://samasaur1.github.io/DiceKit/docs/v$VERSION)" | tee -a body.md
     - uses: ncipollo/release-action@v1.10.0
       with:
         name: ${{ env.NAME }}

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,7 +2,7 @@ clean: true
 author: Samasaur
 author_url: https://github.com/Samasaur1
 module: DiceKit
-module_version: 0.25.0
+module_version: 0.25.1
 # docset_icon:
 github_url: https://github.com/Samasaur1/DiceKit
 # github_file_prefix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -297,7 +297,8 @@ Update .travis.yml in case https://swiftenv.fuller.li/install.sh is down/has no 
 - `Roll`: the result of rolling a `Rollable`
 - `Rollable`: a protocol for anything that is rollable
 
-[Upcoming]: https://github.com/Samasaur1/DiceKit/compare/v0.25.0...master
+[Upcoming]: https://github.com/Samasaur1/DiceKit/compare/v0.25.1...master
+[0.25.0]: https://github.com/Samasaur1/DiceKit/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/Samasaur1/DiceKit/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/Samasaur1/DiceKit/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/Samasaur1/DiceKit/compare/v0.23.0...v0.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,7 +298,7 @@ Update .travis.yml in case https://swiftenv.fuller.li/install.sh is down/has no 
 - `Rollable`: a protocol for anything that is rollable
 
 [Upcoming]: https://github.com/Samasaur1/DiceKit/compare/v0.25.1...master
-[0.25.0]: https://github.com/Samasaur1/DiceKit/compare/v0.25.0...v0.25.1
+[0.25.1]: https://github.com/Samasaur1/DiceKit/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/Samasaur1/DiceKit/compare/v0.24.1...v0.25.0
 [0.24.1]: https://github.com/Samasaur1/DiceKit/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/Samasaur1/DiceKit/compare/v0.23.0...v0.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming]
 
+## [0.25.1] — 2022-06-04
+### Fixed
+- Automated deployment should now work for docs and releases
+
 ## [0.25.0] — 2022-06-04
 ### Added
 - Releases are now auto-deployed from GitHub Actions


### PR DESCRIPTION
The previous version, #90, tried to automate deployment on GitHub Actions. However, it currently does not work. I believe this is due to using `'` instead of `"` for a step in the deploy workflow file, which prohibited bash from substituting in variables. This PR should fix that.